### PR TITLE
Fix issue #10 with None values

### DIFF
--- a/src/FsUnit.CustomMatchers/CustomMatchers.fs
+++ b/src/FsUnit.CustomMatchers/CustomMatchers.fs
@@ -5,7 +5,7 @@ open System.Collections
 open NHamcrest
 open NHamcrest.Core
 
-let equal x = CustomMatcher<obj>(sprintf "Equals %s" (x.ToString()), fun a -> a = x)
+let equal x = CustomMatcher<obj>(sprintf "Equals %A" x, fun a -> a = x)
 
 //TODO: Look into a better way of doing this.
 let equalWithin (t:obj) (x:obj) = CustomMatcher<obj>(sprintf "%s with a tolerance of %s" (x.ToString()) (t.ToString()), 

--- a/tests/FsUnit.MbUnit.Test/equalTests.fs
+++ b/tests/FsUnit.MbUnit.Test/equalTests.fs
@@ -72,3 +72,8 @@ type ``equal Tests`` ()=
     [<Test>] member test.
      ``should pass when comparing two arrays that do not have the same values`` ()=
         [|1|] |> should not (equal [|2|])
+
+    [<Test>] member test.
+     ``None should equal None`` ()=
+        None |> should equal None
+

--- a/tests/FsUnit.MsTest.Test/equalTests.fs
+++ b/tests/FsUnit.MsTest.Test/equalTests.fs
@@ -57,3 +57,7 @@ type ``equal Tests`` ()=
      ``should pass when negated and Equals returns false`` ()=
         anObj |> should not (equal (new NeverEqual()))
 
+    [<TestMethod>] member test.
+     ``None should equal None`` ()=
+        None |> should equal None
+

--- a/tests/FsUnit.NUnit.Test/equalTests.fs
+++ b/tests/FsUnit.NUnit.Test/equalTests.fs
@@ -65,3 +65,7 @@ type ``equal Tests`` ()=
     [<Test>] member test.
      ``should fail when negated and Equals returns true`` ()=
         shouldFail (fun () -> anObj |> should not (equal (new AlwaysEqual())))
+
+    [<Test>] member test.
+     ``None should equal None`` ()=
+        None |> should equal None

--- a/tests/FsUnit.Xunit.Test/equalTests.fs
+++ b/tests/FsUnit.Xunit.Test/equalTests.fs
@@ -71,3 +71,7 @@ type ``equal Tests`` ()=
     [<Fact>] member test.
      ``should pass when comparing two arrays that do not have the same values`` ()=
         [|1|] |> should not (equal [|2|])
+
+    [<Fact>] member test.
+     ``None should equal None`` ()=
+        None |> should equal None    


### PR DESCRIPTION
This pull request contains fix of issue #10 with None values.
Before the fix code like `None |> should equal None` throw NullReferenceException in MsTest, Mb an X units.
Now it works correctly across all test frameworks. This also fixes test code mentioned in the issue

Please review.
