### PR TITLE
Added throwWithMessage

### DIFF
--- a/src/FsUnit.CustomMatchers/CustomMatchers.fs
+++ b/src/FsUnit.CustomMatchers/CustomMatchers.fs
@@ -30,6 +30,16 @@ let throw (t:Type) = CustomMatcher<obj>(string t,
                                       | ex -> if ex.GetType() = t then true else false
                                   | _ -> false )
 
+let throwWithMessage (m:string) (t:Type) = CustomMatcher<obj>(sprintf "%s \"%s\"" (string t) m, 
+                         fun f -> match f with
+                                  | :? (unit -> unit) as testFunc -> 
+                                      try
+                                        testFunc() 
+                                        false
+                                      with
+                                      | ex -> if ex.GetType() = t && ex.Message = m then true else false
+                                  | _ -> false )
+
 let be = id
 
 let Null = Is.Null()

--- a/src/FsUnit.MbUnit/FsUnit.fs
+++ b/src/FsUnit.MbUnit/FsUnit.fs
@@ -21,6 +21,8 @@ let not' (expected:obj) = CustomMatchers.not' expected
 
 let throw (t:Type) = CustomMatchers.throw t
 
+let throwWithMessage (m:string) (t:Type) = CustomMatchers.throwWithMessage m t
+
 let be = CustomMatchers.be
 
 let Null = CustomMatchers.Null

--- a/src/FsUnit.MsTestUnit/FsUnit.fs
+++ b/src/FsUnit.MsTestUnit/FsUnit.fs
@@ -30,6 +30,8 @@ let not' (expected:obj) = CustomMatchers.not' expected
 
 let throw (t:Type) = CustomMatchers.throw t
 
+let throwWithMessage (m:string) (t:Type) = CustomMatchers.throwWithMessage m t
+
 let be = CustomMatchers.be
 
 let Null = CustomMatchers.Null

--- a/src/FsUnit.NUnit/FsUnit.fs
+++ b/src/FsUnit.NUnit/FsUnit.fs
@@ -49,6 +49,8 @@ module TopLevelOperators =
 
     let throw = Throws.TypeOf
 
+    let throwWithMessage (m:string) (t:System.Type) = Throws.TypeOf(t).And.Message.EqualTo(m)
+
     let greaterThan x = GreaterThanConstraint(x)
 
     let greaterThanOrEqualTo x = GreaterThanOrEqualConstraint(x)

--- a/src/FsUnit.Xunit/FsUnit.fs
+++ b/src/FsUnit.Xunit/FsUnit.fs
@@ -34,6 +34,8 @@ let not' (expected:obj) = CustomMatchers.not' expected
 
 let throw (t:Type) = CustomMatchers.throw t
 
+let throwWithMessage (m:string) (t:Type) = CustomMatchers.throwWithMessage m t
+
 let be = CustomMatchers.be
 
 let Null = CustomMatchers.Null

--- a/tests/FsUnit.MbUnit.Test/raiseTests.fs
+++ b/tests/FsUnit.MbUnit.Test/raiseTests.fs
@@ -28,3 +28,31 @@ type ``raise tests`` ()=
     [<Test>] member test.
      ``should fail when exception thrown is not the type expected`` ()=
             (fun () -> raise TestException |> ignore) |> should not (throw typeof<ApplicationException>)
+
+    [<Test>] member test.
+     ``should pass when exception of expected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should (throwWithMessage msg) typeof<ApplicationException>
+
+    [<Test>] member test.
+     ``should fail when exception of expected type with unexpected message is thrown`` ()=
+            (fun () -> raise (ApplicationException "BOOM!") |> ignore) |> should (throwWithMessage "CRASH!") typeof<ApplicationException>
+
+    [<Test>] member test.
+     ``should fail when exception of unexpected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should (throwWithMessage msg) typeof<ArgumentException>
+
+    [<Test>] member test.
+     ``should fail when negated and exception of expected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should not ((throwWithMessage msg) typeof<ApplicationException>)
+
+    [<Test>] member test.
+     ``should pass when negated and exception of expected type with unexpected message is thrown`` ()=
+            (fun () -> raise (ApplicationException "BOOM!") |> ignore) |> should not ((throwWithMessage "CRASH!") typeof<ApplicationException>)
+
+    [<Test>] member test.
+     ``should pass when negated and exception of unexpected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should not ((throwWithMessage msg) typeof<ArgumentException>)

--- a/tests/FsUnit.MsTest.Test/raiseTests.fs
+++ b/tests/FsUnit.MsTest.Test/raiseTests.fs
@@ -27,3 +27,31 @@ type ``raise tests`` ()=
     [<TestMethod>] member test.
      ``should fail when exception thrown is not the type expected`` ()=
             (fun () -> raise TestException |> ignore) |> should not (throw typeof<ApplicationException>)
+
+    [<TestMethod>] member test.
+     ``should pass when exception of expected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should (throwWithMessage msg) typeof<ApplicationException>
+
+    [<TestMethod>] member test.
+     ``should fail when exception of expected type with unexpected message is thrown`` ()=
+            (fun () -> raise (ApplicationException "BOOM!") |> ignore) |> should (throwWithMessage "CRASH!") typeof<ApplicationException>
+
+    [<TestMethod>] member test.
+     ``should fail when exception of unexpected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should (throwWithMessage msg) typeof<ArgumentException>
+
+    [<TestMethod>] member test.
+     ``should fail when negated and exception of expected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should not ((throwWithMessage msg) typeof<ApplicationException>)
+
+    [<TestMethod>] member test.
+     ``should pass when negated and exception of expected type with unexpected message is thrown`` ()=
+            (fun () -> raise (ApplicationException "BOOM!") |> ignore) |> should not ((throwWithMessage "CRASH!") typeof<ApplicationException>)
+
+    [<TestMethod>] member test.
+     ``should pass when negated and exception of unexpected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should not ((throwWithMessage msg) typeof<ArgumentException>)

--- a/tests/FsUnit.NUnit.Test/raiseTests.fs
+++ b/tests/FsUnit.NUnit.Test/raiseTests.fs
@@ -30,3 +30,31 @@ type ``raise tests`` ()=
      ``should fail when exception thrown is not the type expected`` ()=
         shouldFail (fun () -> 
             (fun () -> raise TestException |> ignore) |> should throw typeof<ApplicationException>)
+
+    [<Test>] member test.
+     ``should pass when exception of expected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should (throwWithMessage msg) typeof<ApplicationException>
+
+    [<Test>] member test.
+     ``should fail when exception of expected type with unexpected message is thrown`` ()=
+            (fun () -> raise (ApplicationException "BOOM!") |> ignore) |> should (throwWithMessage "CRASH!") typeof<ApplicationException>
+
+    [<Test>] member test.
+     ``should fail when exception of unexpected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should (throwWithMessage msg) typeof<ArgumentException>
+
+    [<Test>] member test.
+     ``should fail when negated and exception of expected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should not ((throwWithMessage msg) typeof<ApplicationException>)
+
+    [<Test>] member test.
+     ``should pass when negated and exception of expected type with unexpected message is thrown`` ()=
+            (fun () -> raise (ApplicationException "BOOM!") |> ignore) |> should not ((throwWithMessage "CRASH!") typeof<ApplicationException>)
+
+    [<Test>] member test.
+     ``should pass when negated and exception of unexpected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should not ((throwWithMessage msg) typeof<ArgumentException>)

--- a/tests/FsUnit.Xunit.Test/raiseTests.fs
+++ b/tests/FsUnit.Xunit.Test/raiseTests.fs
@@ -27,3 +27,31 @@ type ``raise tests`` ()=
     [<Fact>] member test.
      ``should fail when exception thrown is not the type expected`` ()=
             (fun () -> raise TestException |> ignore) |> should not (throw typeof<ApplicationException>)
+
+    [<Fact>] member test.
+     ``should pass when exception of expected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should (throwWithMessage msg) typeof<ApplicationException>
+
+    [<Fact>] member test.
+     ``should fail when exception of expected type with unexpected message is thrown`` ()=
+            (fun () -> raise (ApplicationException "BOOM!") |> ignore) |> should (throwWithMessage "CRASH!") typeof<ApplicationException>
+
+    [<Fact>] member test.
+     ``should fail when exception of unexpected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should (throwWithMessage msg) typeof<ArgumentException>
+
+    [<Fact>] member test.
+     ``should fail when negated and exception of expected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should not ((throwWithMessage msg) typeof<ApplicationException>)
+
+    [<Fact>] member test.
+     ``should pass when negated and exception of expected type with unexpected message is thrown`` ()=
+            (fun () -> raise (ApplicationException "BOOM!") |> ignore) |> should not ((throwWithMessage "CRASH!") typeof<ApplicationException>)
+
+    [<Fact>] member test.
+     ``should pass when negated and exception of unexpected type with expected message is thrown`` ()=
+            let msg = "BOOM!" in
+            (fun () -> raise (ApplicationException msg) |> ignore) |> should not ((throwWithMessage msg) typeof<ArgumentException>)


### PR DESCRIPTION
I thought it might be useful to have this functionality for those scenarios where the exact exception message matters.
