### PR TITLE
Rename depricated -> deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Deprecated Functions
 
 Prior to version 1.1.0.0, FsUnit implemented a function named `not` that overwrote the F# operator of the same name. This is not ideal, 
 so as of version 1.1.0.0 the FsUnit function has been renamed to `not'` (not + single-quote). If you need or want the previous function, it 
-can be made available by opening the FsUnitDepricated module. 
+can be made available by opening the FsUnitDeprecated module. 
 
 Visual Studio 11 Support
 =======

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 if [ ! -f packages/FAKE/tools/Fake.exe ]; then
   mono --runtime=v4.0 .nuget/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion  -Prerelease
 fi
-mono --runtime=v4.0 packages/FAKE/tools/FAKE.exe build.fsx $@
+mono --runtime=v4.0 packages/FAKE/tools/FAKE.exe build.fsx "$@"

--- a/src/FsUnit.MbUnit/FsUnit.fs
+++ b/src/FsUnit.MbUnit/FsUnit.fs
@@ -61,7 +61,7 @@ let ascending = CustomMatchers.ascending
 
 let descending = CustomMatchers.descending
 
-module FsUnitDepricated = 
+module FsUnitDeprecated = 
     let not x = not' x
 
 // haveLength, haveCount, Empty, and shouldFail are not implemented for MbUnit and xUnit

--- a/src/FsUnit.MsTestUnit/FsUnit.fs
+++ b/src/FsUnit.MsTestUnit/FsUnit.fs
@@ -70,7 +70,7 @@ let ascending = CustomMatchers.ascending
 
 let descending = CustomMatchers.descending
 
-module FsUnitDepricated =
+module FsUnitDeprecated =
     let not x = not' x 
 
 // haveLength, haveCount, Empty, and shouldFail are not implemented for MbUnit, xUnit, or MsTest 

--- a/src/FsUnit.NUnit/FsUnit.fs
+++ b/src/FsUnit.NUnit/FsUnit.fs
@@ -91,6 +91,6 @@ module TopLevelOperators =
     let not' x = NotConstraint(x)
 
     /// Deprecated operators. These will be removed in a future version of FsUnit.
-    module FsUnitDepricated =
+    module FsUnitDeprecated =
         [<System.Obsolete>]
         let not x = not' x

--- a/src/FsUnit.NUnit/FsUnit.fs
+++ b/src/FsUnit.NUnit/FsUnit.fs
@@ -76,6 +76,8 @@ module TopLevelOperators =
 
     let startWith (s:string) = StartsWithConstraint s
 
+    let haveSubstring (s:string) = SubstringConstraint s
+
     let ofExactType<'a> = ExactTypeConstraint(typeof<'a>)
 
     let instanceOfType<'a> = InstanceOfTypeConstraint(typeof<'a>)

--- a/src/FsUnit.Xunit/FsUnit.fs
+++ b/src/FsUnit.Xunit/FsUnit.fs
@@ -74,7 +74,7 @@ let ascending = CustomMatchers.ascending
 
 let descending = CustomMatchers.descending
 
-module FsUnitDepricated = 
+module FsUnitDeprecated = 
     let not x = not' x
 
 // haveLength, haveCount, Empty, and shouldFail are not implemented for MbUnit and xUnit

--- a/tests/FsUnit.MbUnit.Test/beAscendingTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beAscendingTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be ascending tests`` ()=
     [<Test>] member test.

--- a/tests/FsUnit.MbUnit.Test/beDescendingTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beDescendingTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be descending tests`` ()=
     [<Test>] member test.

--- a/tests/FsUnit.MbUnit.Test/beEmptyStringTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beEmptyStringTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be EmptyString tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/beEmptyTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beEmptyTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be Empty tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/beFalseTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beFalseTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be False tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/beGreaterThanOrEqualTo.fs
+++ b/tests/FsUnit.MbUnit.Test/beGreaterThanOrEqualTo.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be greaterThanOrEqualTo tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/beGreaterThanTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beGreaterThanTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be greaterThan tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/beLessThanOrEqualToTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beLessThanOrEqualToTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be lessThanOrEqualTo tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/beLessThanTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beLessThanTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be lessThan tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/beNullOrEmptyStringTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beNullOrEmptyStringTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be NullOrEmptyString tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/beNullTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beNullTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be Null tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/beOfExactTypeTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beOfExactTypeTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``should be of exact type tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/beSameAsTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beSameAsTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be SameAs tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/beTrueTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beTrueTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be True tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/containTests.fs
+++ b/tests/FsUnit.MbUnit.Test/containTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open MbUnit.Framework
 open FsUnit.MbUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``contain tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/equalTests.fs
+++ b/tests/FsUnit.MbUnit.Test/equalTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type AlwaysEqual() =
     override this.Equals(other) = true

--- a/tests/FsUnit.MbUnit.Test/haveCountTests.fs
+++ b/tests/FsUnit.MbUnit.Test/haveCountTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``have Count tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/haveLengthTests.fs
+++ b/tests/FsUnit.MbUnit.Test/haveLengthTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``haveLength tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/matchListTests.fs
+++ b/tests/FsUnit.MbUnit.Test/matchListTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``match List tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/raiseTests.fs
+++ b/tests/FsUnit.MbUnit.Test/raiseTests.fs
@@ -3,7 +3,7 @@ open System
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 exception TestException
 

--- a/tests/FsUnit.MbUnit.Test/shouldEndWithTests.fs
+++ b/tests/FsUnit.MbUnit.Test/shouldEndWithTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``should endWith tests`` ()=

--- a/tests/FsUnit.MbUnit.Test/shouldStartWithTests.fs
+++ b/tests/FsUnit.MbUnit.Test/shouldStartWithTests.fs
@@ -2,7 +2,7 @@
 open MbUnit.Framework
 open FsUnit.MbUnit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``should startWith tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beAscendingTests.fs
+++ b/tests/FsUnit.MsTest.Test/beAscendingTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be ascending tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beDescendingTests.fs
+++ b/tests/FsUnit.MsTest.Test/beDescendingTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be descending tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beEmptyStringTests.fs
+++ b/tests/FsUnit.MsTest.Test/beEmptyStringTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be EmptyString tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beEmptyTests.fs
+++ b/tests/FsUnit.MsTest.Test/beEmptyTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be Empty tests`` ()=
     [<TestMethod>] member test.

--- a/tests/FsUnit.MsTest.Test/beFalseTests.fs
+++ b/tests/FsUnit.MsTest.Test/beFalseTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be False tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beGreaterThanOrEqualTo.fs
+++ b/tests/FsUnit.MsTest.Test/beGreaterThanOrEqualTo.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be greaterThanOrEqualTo tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beGreaterThanTests.fs
+++ b/tests/FsUnit.MsTest.Test/beGreaterThanTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be greaterThan tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beLessThanOrEqualToTests.fs
+++ b/tests/FsUnit.MsTest.Test/beLessThanOrEqualToTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be lessThanOrEqualTo tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beLessThanTests.fs
+++ b/tests/FsUnit.MsTest.Test/beLessThanTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be lessThan tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beNullOrEmptyStringTests.fs
+++ b/tests/FsUnit.MsTest.Test/beNullOrEmptyStringTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be NullOrEmptyString tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beNullTests.fs
+++ b/tests/FsUnit.MsTest.Test/beNullTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be Null tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beOfExactTypeTests.fs
+++ b/tests/FsUnit.MsTest.Test/beOfExactTypeTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``should be of exact type tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beSameAsTests.fs
+++ b/tests/FsUnit.MsTest.Test/beSameAsTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be SameAs tests`` ()=

--- a/tests/FsUnit.MsTest.Test/beTrueTests.fs
+++ b/tests/FsUnit.MsTest.Test/beTrueTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``be True tests`` ()=

--- a/tests/FsUnit.MsTest.Test/containTests.fs
+++ b/tests/FsUnit.MsTest.Test/containTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``contain tests`` ()=

--- a/tests/FsUnit.MsTest.Test/equalTests.fs
+++ b/tests/FsUnit.MsTest.Test/equalTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type AlwaysEqual() =
     override this.Equals(other) = true

--- a/tests/FsUnit.MsTest.Test/equalWithinTests.fs
+++ b/tests/FsUnit.MsTest.Test/equalWithinTests.fs
@@ -2,7 +2,7 @@
 
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
-open FsUnitDepricated
+open FsUnitDeprecated
 
 (* Thanks to erdoll for this suggestion: http://fsunit.codeplex.com/discussions/269320 *)
 

--- a/tests/FsUnit.MsTest.Test/haveCountTests.fs
+++ b/tests/FsUnit.MsTest.Test/haveCountTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``have Count tests`` ()=

--- a/tests/FsUnit.MsTest.Test/haveLengthTests.fs
+++ b/tests/FsUnit.MsTest.Test/haveLengthTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``haveLength tests`` ()=

--- a/tests/FsUnit.MsTest.Test/matchListTests.fs
+++ b/tests/FsUnit.MsTest.Test/matchListTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``match List tests`` ()=
     [<TestMethod>] member test.

--- a/tests/FsUnit.MsTest.Test/raiseTests.fs
+++ b/tests/FsUnit.MsTest.Test/raiseTests.fs
@@ -3,7 +3,7 @@ open System
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 exception TestException
 [<TestClass>]

--- a/tests/FsUnit.MsTest.Test/shouldEndWithTests.fs
+++ b/tests/FsUnit.MsTest.Test/shouldEndWithTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``should endWith tests`` ()=

--- a/tests/FsUnit.MsTest.Test/shouldStartWithTests.fs
+++ b/tests/FsUnit.MsTest.Test/shouldStartWithTests.fs
@@ -2,7 +2,7 @@
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestClass>]
 type ``should startWith tests`` ()=

--- a/tests/FsUnit.NUnit.Test/FsUnit.NUnit.Test.fsproj
+++ b/tests/FsUnit.NUnit.Test/FsUnit.NUnit.Test.fsproj
@@ -70,6 +70,7 @@
     <Compile Include="shouldFailTests.fs" />
     <Compile Include="shouldEndWithTests.fs" />
     <Compile Include="shouldStartWithTests.fs" />
+    <Compile Include="shouldHaveSubstringTests.fs" />
     <Compile Include="beOfExactTypeTests.fs" />
     <Compile Include="beGreaterThanOrEqualTo.fs" />
     <Compile Include="beLessThanOrEqualToTests.fs" />

--- a/tests/FsUnit.NUnit.Test/NaNTests.fs
+++ b/tests/FsUnit.NUnit.Test/NaNTests.fs
@@ -2,7 +2,7 @@
 open NUnit.Framework
 open FsUnit
 open System
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``Not a Number tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beAscendingTests.fs
+++ b/tests/FsUnit.NUnit.Test/beAscendingTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be ascending tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beDescendingTests.fs
+++ b/tests/FsUnit.NUnit.Test/beDescendingTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be descending tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beEmptyStringTests.fs
+++ b/tests/FsUnit.NUnit.Test/beEmptyStringTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be EmptyString tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beEmptyTests.fs
+++ b/tests/FsUnit.NUnit.Test/beEmptyTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be Empty tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beFalseTests.fs
+++ b/tests/FsUnit.NUnit.Test/beFalseTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be False tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beGreaterThanOrEqualTo.fs
+++ b/tests/FsUnit.NUnit.Test/beGreaterThanOrEqualTo.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be greaterThanOrEqualTo tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beGreaterThanTests.fs
+++ b/tests/FsUnit.NUnit.Test/beGreaterThanTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be greaterThan tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beLessThanOrEqualToTests.fs
+++ b/tests/FsUnit.NUnit.Test/beLessThanOrEqualToTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be lessThanOrEqualTo tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beLessThanTests.fs
+++ b/tests/FsUnit.NUnit.Test/beLessThanTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be lessThan tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beNullOrEmptyStringTests.fs
+++ b/tests/FsUnit.NUnit.Test/beNullOrEmptyStringTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be NullOrEmptyString tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beNullTests.fs
+++ b/tests/FsUnit.NUnit.Test/beNullTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be Null tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beOfExactTypeTests.fs
+++ b/tests/FsUnit.NUnit.Test/beOfExactTypeTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``should be of exact type tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beSameAsTests.fs
+++ b/tests/FsUnit.NUnit.Test/beSameAsTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be SameAs tests`` ()=

--- a/tests/FsUnit.NUnit.Test/beTrueTests.fs
+++ b/tests/FsUnit.NUnit.Test/beTrueTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``be True tests`` ()=

--- a/tests/FsUnit.NUnit.Test/containTests.fs
+++ b/tests/FsUnit.NUnit.Test/containTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``contain tests`` ()=

--- a/tests/FsUnit.NUnit.Test/equalTests.fs
+++ b/tests/FsUnit.NUnit.Test/equalTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type AlwaysEqual() =
     override this.Equals(other) = true

--- a/tests/FsUnit.NUnit.Test/equalWithinTests.fs
+++ b/tests/FsUnit.NUnit.Test/equalWithinTests.fs
@@ -2,7 +2,7 @@
 
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 (* Thanks to erdoll for this suggestion: http://fsunit.codeplex.com/discussions/269320 *)
 

--- a/tests/FsUnit.NUnit.Test/haveCountTests.fs
+++ b/tests/FsUnit.NUnit.Test/haveCountTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``have Count tests`` ()=

--- a/tests/FsUnit.NUnit.Test/haveLengthTests.fs
+++ b/tests/FsUnit.NUnit.Test/haveLengthTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``haveLength tests`` ()=

--- a/tests/FsUnit.NUnit.Test/instanceOfTests.fs
+++ b/tests/FsUnit.NUnit.Test/instanceOfTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``Instance Of tests`` ()=

--- a/tests/FsUnit.NUnit.Test/raiseTests.fs
+++ b/tests/FsUnit.NUnit.Test/raiseTests.fs
@@ -2,7 +2,7 @@
 open System
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 exception TestException
 

--- a/tests/FsUnit.NUnit.Test/shouldEndWithTests.fs
+++ b/tests/FsUnit.NUnit.Test/shouldEndWithTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``should endWith tests`` ()=

--- a/tests/FsUnit.NUnit.Test/shouldHaveSubstringTests.fs
+++ b/tests/FsUnit.NUnit.Test/shouldHaveSubstringTests.fs
@@ -1,0 +1,19 @@
+﻿namespace FsUnit.Test
+open NUnit.Framework
+open FsUnit
+open FsUnitDepricated
+
+[<TestFixture>]
+type ``should haveSubstring tests`` ()=
+    [<Test>] member test.
+     ``empty string should contain ""`` ()=
+        "" |> should haveSubstring ""
+
+    [<Test>] member test.
+     ``ships should contain hip`` ()=
+        "ships" |> should haveSubstring "hip"
+
+    [<Test>] member test.
+     ``ships should not contain haps`` ()=
+        "ships" |> should not (haveSubstring "haps")
+

--- a/tests/FsUnit.NUnit.Test/shouldHaveSubstringTests.fs
+++ b/tests/FsUnit.NUnit.Test/shouldHaveSubstringTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``should haveSubstring tests`` ()=

--- a/tests/FsUnit.NUnit.Test/shouldStartWithTests.fs
+++ b/tests/FsUnit.NUnit.Test/shouldStartWithTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 [<TestFixture>]
 type ``should startWith tests`` ()=

--- a/tests/FsUnit.Xunit.Test/beAscendingTests.fs
+++ b/tests/FsUnit.Xunit.Test/beAscendingTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be ascending tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beDescendingTests.fs
+++ b/tests/FsUnit.Xunit.Test/beDescendingTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be descending tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beEmptyStringTests.fs
+++ b/tests/FsUnit.Xunit.Test/beEmptyStringTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be EmptyString tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beEmptyTests.fs
+++ b/tests/FsUnit.Xunit.Test/beEmptyTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be Empty tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beFalseTests.fs
+++ b/tests/FsUnit.Xunit.Test/beFalseTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be False tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beGreaterThanOrEqualTo.fs
+++ b/tests/FsUnit.Xunit.Test/beGreaterThanOrEqualTo.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be greaterThanOrEqualTo tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beGreaterThanTests.fs
+++ b/tests/FsUnit.Xunit.Test/beGreaterThanTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be greaterThan tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beLessThanOrEqualToTests.fs
+++ b/tests/FsUnit.Xunit.Test/beLessThanOrEqualToTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be lessThanOrEqualTo tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beLessThanTests.fs
+++ b/tests/FsUnit.Xunit.Test/beLessThanTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be lessThan tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beNullOrEmptyStringTests.fs
+++ b/tests/FsUnit.Xunit.Test/beNullOrEmptyStringTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be NullOrEmptyString tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beNullTests.fs
+++ b/tests/FsUnit.Xunit.Test/beNullTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be Null tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beOfExactTypeTests.fs
+++ b/tests/FsUnit.Xunit.Test/beOfExactTypeTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``should be of exact type tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/beSameAsTests.fs
+++ b/tests/FsUnit.Xunit.Test/beSameAsTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be SameAs tests`` ()=
     let anObj = new obj()

--- a/tests/FsUnit.Xunit.Test/beTrueTests.fs
+++ b/tests/FsUnit.Xunit.Test/beTrueTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``be True tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/containTests.fs
+++ b/tests/FsUnit.Xunit.Test/containTests.fs
@@ -1,7 +1,7 @@
 ﻿namespace FsUnit.Test
 open Xunit
 open FsUnit.Xunit
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``contain tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/equalTests.fs
+++ b/tests/FsUnit.Xunit.Test/equalTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type AlwaysEqual() =
     override this.Equals(other) = true

--- a/tests/FsUnit.Xunit.Test/haveCountTests.fs
+++ b/tests/FsUnit.Xunit.Test/haveCountTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``have Count tests`` ()=
     let emptyList = new System.Collections.Generic.List<int>()

--- a/tests/FsUnit.Xunit.Test/haveLengthTests.fs
+++ b/tests/FsUnit.Xunit.Test/haveLengthTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``haveLength tests`` ()=
     // F# List

--- a/tests/FsUnit.Xunit.Test/matchListTests.fs
+++ b/tests/FsUnit.Xunit.Test/matchListTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``match List tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/raiseTests.fs
+++ b/tests/FsUnit.Xunit.Test/raiseTests.fs
@@ -3,7 +3,7 @@ open System
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 exception TestException
 

--- a/tests/FsUnit.Xunit.Test/shouldEndWithTests.fs
+++ b/tests/FsUnit.Xunit.Test/shouldEndWithTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``should endWith tests`` ()=
     [<Fact>] member test.

--- a/tests/FsUnit.Xunit.Test/shouldStartWithTests.fs
+++ b/tests/FsUnit.Xunit.Test/shouldStartWithTests.fs
@@ -2,7 +2,7 @@
 open Xunit
 open FsUnit.Xunit
 open NHamcrest.Core
-open FsUnitDepricated
+open FsUnitDeprecated
 
 type ``should startWith tests`` ()=
     [<Fact>] member test.


### PR DESCRIPTION
I accept that this change is not backward compatible. However, I think it is worth doing. Probably very few people use this module and it doesn't look great to have a spelling mistake in a module name under the fsharp org.