### PR TITLE
fsharp-friendly string formatting for failed equals constraint

### DIFF
--- a/src/FsUnit.NUnit/FsUnit.fs
+++ b/src/FsUnit.NUnit/FsUnit.fs
@@ -16,6 +16,17 @@ type ChoiceConstraint(n) =
         | null -> raise (new ArgumentException("The actual value must be a non-null choice"))
         | o -> (new CustomMatchers.ChoiceDiscriminator(n)).check(o)
 
+/// F#-friendly formatting for otherwise the same equals behavior (%A instead of .ToString())
+type EqualsConstraint(x:obj) =
+  inherit EqualConstraint(x) with
+    override this.WriteActualValueTo(writer: MessageWriter): unit =
+      writer.WriteActualValue(sprintf "%A" this.actual)
+    override this.WriteDescriptionTo(writer: MessageWriter): unit =
+      writer.WritePredicate("equals")
+      writer.WriteExpectedValue(sprintf "%A" x)
+    override this.WriteMessageTo(writer: MessageWriter): unit =
+      writer.WriteMessageLine(sprintf "Expected: %A, but was %A" x this.actual)
+
 //
 [<AutoOpen>]
 module TopLevelOperators =
@@ -43,7 +54,7 @@ module TopLevelOperators =
             | _ -> y
         Assert.That(y, c)
     
-    let equal x = EqualConstraint(x)
+    let equal x = EqualsConstraint(x)
 
     let equalWithin tolerance x = equal(x).Within tolerance
 


### PR DESCRIPTION
I don't know how people live with the current failed assertion messages, before:
```fsharp
type R = { a:int }
...
{a=1} |> should equal {a=2} // results in "expect R, but was R" kind of message!
```
after:
```fsharp
...
{a=1} |> should equal {a=2} // results in "expect {a=1}, but was {a=2}" 
```

Seriously, if there's a better way than this change, I'd like to know!