### PR TITLE
#52 - add support for null in should clause

### DIFF
--- a/src/FsUnit.MbUnit/FsUnit.fs
+++ b/src/FsUnit.MbUnit/FsUnit.fs
@@ -30,8 +30,7 @@ let equal expected = CustomMatchers.equal expected
 
 let equalWithin (tolerance:obj) (expected:obj) = CustomMatchers.equalWithin tolerance expected
 
-let not' (expected:obj) =
-    if box expected = null then CustomMatchers.not' (IsNull()) else (CustomMatchers.not' expected)
+let not' (expected:obj) = CustomMatchers.not' expected
 
 let throw (t:Type) = CustomMatchers.throw t
 

--- a/src/FsUnit.MbUnit/FsUnit.fs
+++ b/src/FsUnit.MbUnit/FsUnit.fs
@@ -11,7 +11,10 @@ let inline should (f : 'a -> ^b) x (y : obj) =
         match y with
         | :? (unit -> unit) as assertFunc -> box assertFunc
         | _ -> y
-    Assert.That(y, c)
+    if box c = null then
+        Assert.That(y, IsNull())
+    else 
+        Assert.That(y, c)
 
 let inline shouldFail (f:unit->unit) =
     let failed =
@@ -27,7 +30,8 @@ let equal expected = CustomMatchers.equal expected
 
 let equalWithin (tolerance:obj) (expected:obj) = CustomMatchers.equalWithin tolerance expected
 
-let not' (expected:obj) = CustomMatchers.not' expected
+let not' (expected:obj) =
+    if box expected = null then CustomMatchers.not' (IsNull()) else (CustomMatchers.not' expected)
 
 let throw (t:Type) = CustomMatchers.throw t
 

--- a/src/FsUnit.MsTestUnit/FsUnit.fs
+++ b/src/FsUnit.MsTestUnit/FsUnit.fs
@@ -40,8 +40,7 @@ let equal expected = CustomMatchers.equal expected
 
 let equalWithin (tolerance:obj) (expected:obj) = CustomMatchers.equalWithin tolerance expected
 
-let not' (expected:obj) =
-    if box expected = null then CustomMatchers.not' (IsNull()) else (CustomMatchers.not' expected)
+let not' (expected:obj) = CustomMatchers.not' expected
 
 let throw (t:Type) = CustomMatchers.throw t
 

--- a/src/FsUnit.MsTestUnit/FsUnit.fs
+++ b/src/FsUnit.MsTestUnit/FsUnit.fs
@@ -20,7 +20,10 @@ let inline should (f : 'a -> ^b) x (y : obj) =
         match y with
         | :? (unit -> unit) as assertFunc -> box assertFunc
         | _ -> y
-    Assert.That(y, c)
+    if box c = null then
+        Assert.That(y, IsNull())
+    else 
+        Assert.That(y, c)
 
 let inline shouldFail (f:unit->unit) =
     let failed =
@@ -37,7 +40,8 @@ let equal expected = CustomMatchers.equal expected
 
 let equalWithin (tolerance:obj) (expected:obj) = CustomMatchers.equalWithin tolerance expected
 
-let not' (expected:obj) = CustomMatchers.not' expected
+let not' (expected:obj) =
+    if box expected = null then CustomMatchers.not' (IsNull()) else (CustomMatchers.not' expected)
 
 let throw (t:Type) = CustomMatchers.throw t
 

--- a/src/FsUnit.NUnit/FsUnit.fs
+++ b/src/FsUnit.NUnit/FsUnit.fs
@@ -42,7 +42,10 @@ module TopLevelOperators =
             match y with
             | :? (unit -> unit) -> box (TestDelegate(y :?> unit -> unit))
             | _ -> y
-        Assert.That(y, c)
+        if box c = null then
+            Assert.That(y, Is.Null)
+        else 
+            Assert.That(y, c)
 
     let equal x = EqualsConstraint(x)
 
@@ -87,7 +90,8 @@ module TopLevelOperators =
 
     let descending = Is.Ordered.Descending
 
-    let not' x = NotConstraint(x)
+    let not' x =
+        if box x = null then NotConstraint(Null) else NotConstraint(x)
 
     /// Deprecated operators. These will be removed in a future version of FsUnit.
     module FsUnitDeprecated =

--- a/src/FsUnit.Xunit/CustomMatchers.fs
+++ b/src/FsUnit.Xunit/CustomMatchers.fs
@@ -18,6 +18,7 @@ let equalWithin (t:obj) (x:obj) = CustomMatcher<obj>(sprintf "%s with a toleranc
                                                               else false )
 
 let not' (x:obj) = match box x with
+                   | null -> Is.Not<obj>(Is.Null())
                    | :? IMatcher<obj> as matcher -> Is.Not<obj>(matcher)
                    |  x -> Is.Not<obj>(CustomMatcher<obj>(sprintf "Equals %s" (x.ToString()), fun a -> a = x) :> IMatcher<obj>)
 

--- a/src/FsUnit.Xunit/FsUnit.fs
+++ b/src/FsUnit.Xunit/FsUnit.fs
@@ -24,7 +24,10 @@ let inline should (f : 'a -> ^b) x (y : obj) =
         match y with
         | :? (unit -> unit) as assertFunc -> box assertFunc
         | _ -> y
-    Assert.That(y, c)
+    if box c = null then
+        Assert.That(y, IsNull())
+    else 
+        Assert.That(y, c)
 
 let inline shouldFail (f:unit->unit) =
     let failed =
@@ -41,7 +44,8 @@ let equal expected = CustomMatchers.equal expected
 
 let equalWithin (tolerance:obj) (expected:obj) = CustomMatchers.equalWithin tolerance expected
 
-let not' (expected:obj) = CustomMatchers.not' expected
+let not' (expected:obj) = 
+    if box expected = null then CustomMatchers.not' (IsNull()) else (CustomMatchers.not' expected)
 
 let throw (t:Type) = CustomMatchers.throw t
 

--- a/src/FsUnit.Xunit/FsUnit.fs
+++ b/src/FsUnit.Xunit/FsUnit.fs
@@ -44,8 +44,7 @@ let equal expected = CustomMatchers.equal expected
 
 let equalWithin (tolerance:obj) (expected:obj) = CustomMatchers.equalWithin tolerance expected
 
-let not' (expected:obj) = 
-    if box expected = null then CustomMatchers.not' (IsNull()) else (CustomMatchers.not' expected)
+let not' (expected:obj) = CustomMatchers.not' expected
 
 let throw (t:Type) = CustomMatchers.throw t
 

--- a/tests/FsUnit.MbUnit.Test/beNullTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beNullTests.fs
@@ -11,12 +11,29 @@ type ``be Null tests`` ()=
 
     [<Test>] member test.
      ``null should fail to not be Null`` ()=
-        null |> should be Null
+        shouldFail (fun () -> null |> should not' (be Null))
 
     [<Test>] member test.
-     ``non-null should fail to be  Null`` ()=
-        "something" |> should not' (be Null)
+     ``non-null should fail to be Null`` ()=
+        shouldFail (fun () -> "something" |> should be Null)
 
     [<Test>] member test.
      ``non-null should not be Null`` ()=
         "something" |> should not' (be Null)
+
+    [<Test>] member test.
+     ``null should be null`` ()=
+        null |> should be null
+
+    [<Test>] member test.
+     ``null should fail to not be null`` ()=
+        shouldFail (fun () -> null |> should not' (be null))
+
+    [<Test>] member test.
+     ``non-null should fail to be null`` ()=
+        shouldFail (fun () -> "something" |> should be null)
+
+    [<Test>] member test.
+     ``non-null should not be null`` ()=
+        "something" |> should not' (be null)
+

--- a/tests/FsUnit.MsTest.Test/beNullTests.fs
+++ b/tests/FsUnit.MsTest.Test/beNullTests.fs
@@ -11,12 +11,28 @@ type ``be Null tests`` ()=
 
     [<TestMethod>] member test.
      ``null should fail to not be Null`` ()=
-        null |> should be Null
+        shouldFail (fun () -> null |> should not' (be Null))
 
     [<TestMethod>] member test.
-     ``non-null should fail to be  Null`` ()=
-        "something" |> should not' (be Null)
+     ``non-null should fail to be Null`` ()=
+        shouldFail (fun () -> "something" |> should be Null)
 
     [<TestMethod>] member test.
      ``non-null should not be Null`` ()=
         "something" |> should not' (be Null)
+
+    [<TestMethod>] member test.
+     ``null should be null`` ()=
+        null |> should be null
+
+    [<TestMethod>] member test.
+     ``null should fail to not be null`` ()=
+        shouldFail (fun () -> null |> should not' (be null))
+
+    [<TestMethod>] member test.
+     ``non-null should fail to be null`` ()=
+        shouldFail (fun () -> "something" |> should be null)
+
+    [<TestMethod>] member test.
+     ``non-null should not be null`` ()=
+        "something" |> should not' (be null)

--- a/tests/FsUnit.NUnit.Test/beNullTests.fs
+++ b/tests/FsUnit.NUnit.Test/beNullTests.fs
@@ -13,9 +13,25 @@ type ``be Null tests`` ()=
         shouldFail (fun () -> null |> should not' (be Null))
 
     [<Test>] member test.
-     ``non-null should fail to be  Null`` ()=
+     ``non-null should fail to be Null`` ()=
         shouldFail (fun () -> "something" |> should be Null)
 
     [<Test>] member test.
      ``non-null should not be Null`` ()=
         "something" |> should not' (be Null)
+
+    [<Test>] member test.
+     ``null should be null`` ()=
+        null |> should be null
+
+    [<Test>] member test.
+     ``null should fail to not be null`` ()=
+        shouldFail (fun () -> null |> should not' (be null))
+
+    [<Test>] member test.
+     ``non-null should fail to be null`` ()=
+        shouldFail (fun () -> "something" |> should be null)
+
+    [<Test>] member test.
+     ``non-null should not be null`` ()=
+        "something" |> should not' (be null)

--- a/tests/FsUnit.Xunit.Test/beNullTests.fs
+++ b/tests/FsUnit.Xunit.Test/beNullTests.fs
@@ -10,12 +10,28 @@ type ``be Null tests`` ()=
 
     [<Fact>] member test.
      ``null should fail to not be Null`` ()=
-        null |> should be Null
+        shouldFail (fun () -> null |> should not' (be Null))
 
     [<Fact>] member test.
-     ``non-null should fail to be  Null`` ()=
-        "something" |> should not' (be Null)
+     ``non-null should fail to be Null`` ()=
+        shouldFail (fun () -> "something" |> should be Null)
 
     [<Fact>] member test.
      ``non-null should not be Null`` ()=
         "something" |> should not' (be Null)
+
+    [<Fact>] member test.
+     ``null should be null`` ()=
+        null |> should be null
+
+    [<Fact>] member test.
+     ``null should fail to not be null`` ()=
+        shouldFail (fun () -> null |> should not' (be null))
+
+    [<Fact>] member test.
+     ``non-null should fail to be null`` ()=
+        shouldFail (fun () -> "something" |> should be null)
+
+    [<Fact>] member test.
+     ``non-null should not be null`` ()=
+        "something" |> should not' (be null)


### PR DESCRIPTION
hi, please review this PR. it contains fix for issue #52. 
Now ```should be null``` should work the same as ```should be Null```