### PR TITLE
Fix of #52 - add support for null in should (replacement for PR #80)

### DIFF
--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -96,8 +96,10 @@ false |> should not' (be True)
 
 null |> should be NullOrEmptyString
 null |> should be Null
+null |> should be null
 
 anObj |> should not' (be Null)
+anObj |> should not' (be null)
 anObj |> should be (sameAs anObj)
 anObj |> should not' (be sameAs otherObj)
 

--- a/src/FsUnit.MbUnit/FsUnit.fs
+++ b/src/FsUnit.MbUnit/FsUnit.fs
@@ -11,7 +11,10 @@ let inline should (f : 'a -> ^b) x (y : obj) =
         match y with
         | :? (unit -> unit) as assertFunc -> box assertFunc
         | _ -> y
-    Assert.That(y, c)
+    if box c = null then
+        Assert.That(y, IsNull())
+    else 
+        Assert.That(y, c)
 
 let inline shouldFail (f:unit->unit) =
     let failed =

--- a/src/FsUnit.MsTestUnit/FsUnit.fs
+++ b/src/FsUnit.MsTestUnit/FsUnit.fs
@@ -20,7 +20,10 @@ let inline should (f : 'a -> ^b) x (y : obj) =
         match y with
         | :? (unit -> unit) as assertFunc -> box assertFunc
         | _ -> y
-    Assert.That(y, c)
+    if box c = null then
+        Assert.That(y, IsNull())
+    else 
+        Assert.That(y, c)
 
 let inline shouldFail (f:unit->unit) =
     let failed =

--- a/src/FsUnit.NUnit/FsUnit.fs
+++ b/src/FsUnit.NUnit/FsUnit.fs
@@ -42,7 +42,10 @@ module TopLevelOperators =
             match y with
             | :? (unit -> unit) -> box (TestDelegate(y :?> unit -> unit))
             | _ -> y
-        Assert.That(y, c)
+        if box c = null then
+            Assert.That(y, Is.Null)
+        else 
+            Assert.That(y, c)
 
     let equal x = EqualsConstraint(x)
 
@@ -87,7 +90,8 @@ module TopLevelOperators =
 
     let descending = Is.Ordered.Descending
 
-    let not' x = NotConstraint(x)
+    let not' x =
+        if box x = null then NotConstraint(Null) else NotConstraint(x)
 
     /// Deprecated operators. These will be removed in a future version of FsUnit.
     module FsUnitDeprecated =

--- a/src/FsUnit.Xunit/CustomMatchers.fs
+++ b/src/FsUnit.Xunit/CustomMatchers.fs
@@ -18,6 +18,7 @@ let equalWithin (t:obj) (x:obj) = CustomMatcher<obj>(sprintf "%s with a toleranc
                                                               else false )
 
 let not' (x:obj) = match box x with
+                   | null -> Is.Not<obj>(Is.Null())
                    | :? IMatcher<obj> as matcher -> Is.Not<obj>(matcher)
                    |  x -> Is.Not<obj>(CustomMatcher<obj>(sprintf "Equals %s" (x.ToString()), fun a -> a = x) :> IMatcher<obj>)
 

--- a/src/FsUnit.Xunit/FsUnit.fs
+++ b/src/FsUnit.Xunit/FsUnit.fs
@@ -24,7 +24,10 @@ let inline should (f : 'a -> ^b) x (y : obj) =
         match y with
         | :? (unit -> unit) as assertFunc -> box assertFunc
         | _ -> y
-    Assert.That(y, c)
+    if box c = null then
+        Assert.That(y, IsNull())
+    else 
+        Assert.That(y, c)
 
 let inline shouldFail (f:unit->unit) =
     let failed =

--- a/tests/FsUnit.MbUnit.Test/beNullTests.fs
+++ b/tests/FsUnit.MbUnit.Test/beNullTests.fs
@@ -11,12 +11,29 @@ type ``be Null tests`` ()=
 
     [<Test>] member test.
      ``null should fail to not be Null`` ()=
-        null |> should be Null
+        shouldFail (fun () -> null |> should not' (be Null))
 
     [<Test>] member test.
-     ``non-null should fail to be  Null`` ()=
-        "something" |> should not' (be Null)
+     ``non-null should fail to be Null`` ()=
+        shouldFail (fun () -> "something" |> should be Null)
 
     [<Test>] member test.
      ``non-null should not be Null`` ()=
         "something" |> should not' (be Null)
+
+    [<Test>] member test.
+     ``null should be null`` ()=
+        null |> should be null
+
+    [<Test>] member test.
+     ``null should fail to not be null`` ()=
+        shouldFail (fun () -> null |> should not' (be null))
+
+    [<Test>] member test.
+     ``non-null should fail to be null`` ()=
+        shouldFail (fun () -> "something" |> should be null)
+
+    [<Test>] member test.
+     ``non-null should not be null`` ()=
+        "something" |> should not' (be null)
+

--- a/tests/FsUnit.MsTest.Test/beNullTests.fs
+++ b/tests/FsUnit.MsTest.Test/beNullTests.fs
@@ -11,12 +11,28 @@ type ``be Null tests`` ()=
 
     [<TestMethod>] member test.
      ``null should fail to not be Null`` ()=
-        null |> should be Null
+        shouldFail (fun () -> null |> should not' (be Null))
 
     [<TestMethod>] member test.
-     ``non-null should fail to be  Null`` ()=
-        "something" |> should not' (be Null)
+     ``non-null should fail to be Null`` ()=
+        shouldFail (fun () -> "something" |> should be Null)
 
     [<TestMethod>] member test.
      ``non-null should not be Null`` ()=
         "something" |> should not' (be Null)
+
+    [<TestMethod>] member test.
+     ``null should be null`` ()=
+        null |> should be null
+
+    [<TestMethod>] member test.
+     ``null should fail to not be null`` ()=
+        shouldFail (fun () -> null |> should not' (be null))
+
+    [<TestMethod>] member test.
+     ``non-null should fail to be null`` ()=
+        shouldFail (fun () -> "something" |> should be null)
+
+    [<TestMethod>] member test.
+     ``non-null should not be null`` ()=
+        "something" |> should not' (be null)

--- a/tests/FsUnit.NUnit.Test/beNullTests.fs
+++ b/tests/FsUnit.NUnit.Test/beNullTests.fs
@@ -13,9 +13,25 @@ type ``be Null tests`` ()=
         shouldFail (fun () -> null |> should not' (be Null))
 
     [<Test>] member test.
-     ``non-null should fail to be  Null`` ()=
+     ``non-null should fail to be Null`` ()=
         shouldFail (fun () -> "something" |> should be Null)
 
     [<Test>] member test.
      ``non-null should not be Null`` ()=
         "something" |> should not' (be Null)
+
+    [<Test>] member test.
+     ``null should be null`` ()=
+        null |> should be null
+
+    [<Test>] member test.
+     ``null should fail to not be null`` ()=
+        shouldFail (fun () -> null |> should not' (be null))
+
+    [<Test>] member test.
+     ``non-null should fail to be null`` ()=
+        shouldFail (fun () -> "something" |> should be null)
+
+    [<Test>] member test.
+     ``non-null should not be null`` ()=
+        "something" |> should not' (be null)

--- a/tests/FsUnit.Xunit.Test/beNullTests.fs
+++ b/tests/FsUnit.Xunit.Test/beNullTests.fs
@@ -10,12 +10,28 @@ type ``be Null tests`` ()=
 
     [<Fact>] member test.
      ``null should fail to not be Null`` ()=
-        null |> should be Null
+        shouldFail (fun () -> null |> should not' (be Null))
 
     [<Fact>] member test.
-     ``non-null should fail to be  Null`` ()=
-        "something" |> should not' (be Null)
+     ``non-null should fail to be Null`` ()=
+        shouldFail (fun () -> "something" |> should be Null)
 
     [<Fact>] member test.
      ``non-null should not be Null`` ()=
         "something" |> should not' (be Null)
+
+    [<Fact>] member test.
+     ``null should be null`` ()=
+        null |> should be null
+
+    [<Fact>] member test.
+     ``null should fail to not be null`` ()=
+        shouldFail (fun () -> null |> should not' (be null))
+
+    [<Fact>] member test.
+     ``non-null should fail to be null`` ()=
+        shouldFail (fun () -> "something" |> should be null)
+
+    [<Fact>] member test.
+     ``non-null should not be null`` ()=
+        "something" |> should not' (be null)


### PR DESCRIPTION
Hi, please review this PR. This is a fix for #52.

Now ```null |> should be null``` doesn't throw ```NullReferenceExcepton```. Changes are back-compatible with previous ```Null``` behaviour, so both
```fsharp
null |> should be Null
null |> should be null 
``` 
are true now. 

MsTest, Xunit and MbUnit ```"null should fail to not be Null"``` tests are changed to reflect what they are really doing - checking that ```null |> should not' (be Null)``` throws assert error. Just like it is done in NUnit tests now.

This PR is a replacement for PR #80 - all changes are squashed into 1 single commit.