### PR TITLE
AssemblyInfo and binding redirect doc

### DIFF
--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -144,6 +144,22 @@ Build the project and then run the command "Add-BindingRedirect projectname" (wh
 Package Manager Console. This command will update the `App.config` to include binding redirects from previous version of `FSharp.Core` to
 FSharp.Core version 4.3.0.0. More information about this command can be found in the [NuGet documentation](http://docs.nuget.org/docs/reference/package-manager-console-powershell-reference).
 
+Test Projects Targeting Higher F# Runtimes
+------------------------------------------
+
+If you build your test project with a target F# runtime greater than the targeted runtime of the FsUnit assembly, you may find FsUnit operators failing at runtime, in which case you need to add a binding redirect to the App.config file.
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <configuration>
+      <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+          <dependentAssembly>
+            <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+            <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.4.0.0" />
+          </dependentAssembly>
+        </assemblyBinding>
+      </runtime>
+    </configuration>
 
 Contributing
 ------------

--- a/src/FsUnit.MbUnit/AssemblyInfo.fs
+++ b/src/FsUnit.MbUnit/AssemblyInfo.fs
@@ -1,9 +1,12 @@
-﻿namespace global
+﻿namespace System
 open System.Reflection
-open System.Runtime.CompilerServices
 
-[<assembly: AssemblyTitle("FsUnit.MbUnit")>]
-[<assembly: AssemblyProduct("FsUnit.MbUnit")>]
-[<assembly: AssemblyVersion("1.3.0.1")>]
-[<assembly: InternalsVisibleTo("FsUnit.MbUnit.Test")>]
-do()
+[<assembly: AssemblyTitleAttribute("FsUnit.MbUnit")>]
+[<assembly: AssemblyProductAttribute("FsUnit")>]
+[<assembly: AssemblyDescriptionAttribute("FsUnit is a set of libraries that makes unit-testing with F# more enjoyable.")>]
+[<assembly: AssemblyVersionAttribute("2.0.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.0.0")>]
+do ()
+
+module internal AssemblyVersionInformation =
+    let [<Literal>] Version = "2.0.0"

--- a/src/FsUnit.MsTestUnit/AssemblyInfo.fs
+++ b/src/FsUnit.MsTestUnit/AssemblyInfo.fs
@@ -1,9 +1,12 @@
-﻿namespace global
+﻿namespace System
 open System.Reflection
-open System.Runtime.CompilerServices
 
-[<assembly: AssemblyTitle("FsUnit.MsTest")>]
-[<assembly: AssemblyProduct("FsUnit.MsTest")>]
-[<assembly: AssemblyVersion("1.3.0.1")>]
-[<assembly: InternalsVisibleTo("FsUnit.MsTest.Test")>]
-do()
+[<assembly: AssemblyTitleAttribute("FsUnit.MsTest")>]
+[<assembly: AssemblyProductAttribute("FsUnit")>]
+[<assembly: AssemblyDescriptionAttribute("FsUnit is a set of libraries that makes unit-testing with F# more enjoyable.")>]
+[<assembly: AssemblyVersionAttribute("2.0.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.0.0")>]
+do ()
+
+module internal AssemblyVersionInformation =
+    let [<Literal>] Version = "2.0.0"

--- a/src/FsUnit.NUnit/AssemblyInfo.fs
+++ b/src/FsUnit.NUnit/AssemblyInfo.fs
@@ -1,9 +1,12 @@
-﻿namespace global
+﻿namespace System
 open System.Reflection
-open System.Runtime.CompilerServices
 
-[<assembly: AssemblyTitle("FsUnit.NUnit")>]
-[<assembly: AssemblyProduct("FsUnit.NUnit")>]
-[<assembly: AssemblyVersion("1.3.0.1")>]
-[<assembly: InternalsVisibleTo("FsUnit.NUnit.Test")>]
-do()
+[<assembly: AssemblyTitleAttribute("FsUnit.NUnit")>]
+[<assembly: AssemblyProductAttribute("FsUnit")>]
+[<assembly: AssemblyDescriptionAttribute("FsUnit is a set of libraries that makes unit-testing with F# more enjoyable.")>]
+[<assembly: AssemblyVersionAttribute("2.0.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.0.0")>]
+do ()
+
+module internal AssemblyVersionInformation =
+    let [<Literal>] Version = "2.0.0"

--- a/src/FsUnit.Xunit/AssemblyInfo.fs
+++ b/src/FsUnit.Xunit/AssemblyInfo.fs
@@ -1,9 +1,12 @@
-﻿namespace global
+﻿namespace System
 open System.Reflection
-open System.Runtime.CompilerServices
 
-[<assembly: AssemblyTitle("FsUnit.Xunit")>]
-[<assembly: AssemblyProduct("FsUnit.Xunit")>]
-[<assembly: AssemblyVersion("1.3.0.1")>]
-[<assembly: InternalsVisibleTo("FsUnit.Xunit.Test")>]
-do()
+[<assembly: AssemblyTitleAttribute("FsUnit.Xunit")>]
+[<assembly: AssemblyProductAttribute("FsUnit")>]
+[<assembly: AssemblyDescriptionAttribute("FsUnit is a set of libraries that makes unit-testing with F# more enjoyable.")>]
+[<assembly: AssemblyVersionAttribute("2.0.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.0.0")>]
+do ()
+
+module internal AssemblyVersionInformation =
+    let [<Literal>] Version = "2.0.0"


### PR DESCRIPTION
1) Running the build script changes the AssemblyInfo files. These should either be gitingnored or the updated files committed to git. This commit commits them.

2) Document binding redirect when test project has higher F# target than FsUnit assemblies.