### PR TITLE
matchList can match empty obj lists

### DIFF
--- a/src/FsUnit.Xunit/CustomMatchers.fs
+++ b/src/FsUnit.Xunit/CustomMatchers.fs
@@ -135,6 +135,7 @@ let containf f = CustomMatcher<obj>(sprintf "Contains %s" (f.ToString()),
 let matchList xs = CustomMatcher<obj>(sprintf "All elements from list %s" (xs.ToString()),
                           fun ys -> match ys with
                                     | :? list<_> as ys' -> List.sort xs = List.sort ys'
+                                    | :? System.Collections.IEnumerable as e -> e |> Seq.cast |> Seq.isEmpty && xs |> Seq.isEmpty
                                     | :? _ -> false)
 
 let private makeOrderedMatcher description comparer =

--- a/tests/FsUnit.MbUnit.Test/matchListTests.fs
+++ b/tests/FsUnit.MbUnit.Test/matchListTests.fs
@@ -10,6 +10,18 @@ type ``match List tests`` ()=
         ([] : List<int>) |> should matchList ([] : List<int>)
 
     [<Test>] member test.
+     ``Empty obj list should match itself`` () =
+        [] |> should matchList []
+
+    [<Test>] member test.
+     ``List with elements should not match empty list`` () =
+        [1] |> should not' (matchList [])
+
+    [<Test>] member test.
+     ``Empty list should not match list with elements`` () =
+        [] |> should not' (matchList ["abc"])
+
+    [<Test>] member test.
      ``Single element list should match itself`` () =
         [1] |> should matchList [1]
 
@@ -24,3 +36,7 @@ type ``match List tests`` ()=
     [<Test>] member test.
      ``Lists with different lengths doesn't match`` () =
         ["something","is","missed"] |> should not' (matchList ["something", "is", "missed", "here"])
+
+    [<Test>] member test.
+     ``Comparing scalar to list should not match`` () =
+        47 |> should not' (matchList [47])

--- a/tests/FsUnit.MsTest.Test/matchListTests.fs
+++ b/tests/FsUnit.MsTest.Test/matchListTests.fs
@@ -10,6 +10,18 @@ type ``match List tests`` ()=
         ([] : List<int>) |> should matchList ([] : List<int>)
 
     [<TestMethod>] member test.
+     ``Empty obj list should match itself`` () =
+        [] |> should matchList []
+
+    [<TestMethod>] member test.
+     ``List with elements should not match empty list`` () =
+        [1] |> should not' (matchList [])
+
+    [<TestMethod>] member test.
+     ``Empty list should not match list with elements`` () =
+        [] |> should not' (matchList ["abc"])
+
+    [<TestMethod>] member test.
      ``Single element list should match itself`` () =
         [1] |> should matchList [1]
 
@@ -24,3 +36,7 @@ type ``match List tests`` ()=
     [<TestMethod>] member test.
      ``Lists with different lengths doesn't match`` () =
         ["something","is","missed"] |> should not' (matchList ["something", "is", "missed", "here"])
+
+    [<TestMethod>] member test.
+     ``Comparing scalar to list should not match`` () =
+        47 |> should not' (matchList [47])

--- a/tests/FsUnit.Xunit.Test/matchListTests.fs
+++ b/tests/FsUnit.Xunit.Test/matchListTests.fs
@@ -9,6 +9,18 @@ type ``match List tests`` ()=
         ([] : List<int>) |> should matchList ([] : List<int>)
 
     [<Fact>] member test.
+     ``Empty obj list should match itself`` () =
+        [] |> should matchList []
+
+    [<Fact>] member test.
+     ``List with elements should not match empty list`` () =
+        [1] |> should not' (matchList [])
+
+    [<Fact>] member test.
+     ``Empty list should not match list with elements`` () =
+        [] |> should not' (matchList ["abc"])
+
+    [<Fact>] member test.
      ``Single element list should match itself`` () =
         [1] |> should matchList [1]
 
@@ -23,3 +35,7 @@ type ``match List tests`` ()=
     [<Fact>] member test.
      ``Lists with different lengths doesn't match`` () =
         ["something","is","missed"] |> should not' (matchList ["something", "is", "missed", "here"])
+
+    [<Fact>] member test.
+     ``Comparing scalar to list should not match`` () =
+        47 |> should not' (matchList [47])


### PR DESCRIPTION
`[] |> should matchList []` would previously fail, requiring something like `[] |> should matchList ([] : int list)` to pass.

No new functionality, really, just allows for a bit cleaner syntax in one edge case.