### PR TITLE
Change shouldBeSmallerThan to fail when passed 2 equal numbers

### DIFF
--- a/src/FsUnit.NUnit/FsUnitTyped.fs
+++ b/src/FsUnit.NUnit/FsUnitTyped.fs
@@ -33,7 +33,7 @@ module TopLevelOperators =
 
     [<DebuggerStepThrough>]
     let shouldBeSmallerThan (x : 'a) (y : 'a) =
-        Assert.GreaterOrEqual(x, y, sprintf "Expected: %A\nActual: %A" x y)
+        Assert.Less(y, x, sprintf "Expected: %A\nActual: %A" x y)
 
     [<DebuggerStepThrough>]
     let shouldBeGreaterThan (x : 'a) (y : 'a) =

--- a/tests/FsUnit.NUnit.Test/typed.shouldBeSmallerThanTests.fs
+++ b/tests/FsUnit.NUnit.Test/typed.shouldBeSmallerThanTests.fs
@@ -9,5 +9,15 @@ type ``shouldBeSmallerThan tests`` ()=
         10 |> shouldBeSmallerThan 11
 
     [<Test>] member test.
+     ``10 should not be less than 10`` ()=
+        (fun () -> 10 |> shouldBeSmallerThan 10)
+        |> shouldFail<AssertionException>
+
+    [<Test>] member test.
      ``10.0 should be less than 10.1`` ()=
         10.0 |> shouldBeSmallerThan 10.1
+
+    [<Test>] member test.
+     ``10.0 should not be less than 10.0`` ()=
+        (fun () -> 10.0 |> shouldBeSmallerThan 10.0)
+        |> shouldFail<AssertionException>


### PR DESCRIPTION
Currently, passing 2 equal numbers to shouldBeSmallerThan will not cause an assertion failure.

This pull request changes it so that it ensures that the inequality is as specified. 