### PR TITLE
Added slighly more meaningful messages to a few matchers

### DIFF
--- a/src/FsUnit.Xunit/CustomMatchers.fs
+++ b/src/FsUnit.Xunit/CustomMatchers.fs
@@ -82,16 +82,16 @@ let unique = CustomMatcher<obj>("All items unique", fun (x:obj) ->
 
 let sameAs x = Is.SameAs<obj>(x)
 
-let greaterThan (x:obj) = CustomMatcher<obj>(string x,
+let greaterThan (x:obj) = CustomMatcher<obj>(sprintf "Greater than %s" (string x),
                                      fun actual -> (unbox actual :> IComparable).CompareTo(unbox x) > 0)
 
-let greaterThanOrEqualTo (x:obj) = CustomMatcher<obj>(string x,
+let greaterThanOrEqualTo (x:obj) = CustomMatcher<obj>(sprintf "Greater than or equal to %s" (string x),
                                               fun actual -> (unbox actual :> IComparable).CompareTo(unbox x) >= 0)
 
-let lessThan (x:obj) = CustomMatcher<obj>(string x,
+let lessThan (x:obj) = CustomMatcher<obj>(sprintf "Less than %s" (string x),
                                     fun actual -> (unbox actual :> IComparable).CompareTo(unbox x) < 0)
 
-let lessThanOrEqualTo (x:obj) = CustomMatcher<obj>(string x,
+let lessThanOrEqualTo (x:obj) = CustomMatcher<obj>(sprintf "Less than or equal to %s" (string x),
                                            fun actual -> (unbox actual :> IComparable).CompareTo(unbox x) <= 0)
 
 let endWith (x:string) = CustomMatcher<obj>(string x, fun s -> (string s).EndsWith x)

--- a/src/FsUnit.Xunit/CustomMatchers.fs
+++ b/src/FsUnit.Xunit/CustomMatchers.fs
@@ -82,16 +82,16 @@ let unique = CustomMatcher<obj>("All items unique", fun (x:obj) ->
 
 let sameAs x = Is.SameAs<obj>(x)
 
-let greaterThan (x:obj) = CustomMatcher<obj>(sprintf "Greater than %s" (string x),
+let greaterThan (x:obj) = CustomMatcher<obj>(sprintf "Greater than %A" x,
                                      fun actual -> (unbox actual :> IComparable).CompareTo(unbox x) > 0)
 
-let greaterThanOrEqualTo (x:obj) = CustomMatcher<obj>(sprintf "Greater than or equal to %s" (string x),
+let greaterThanOrEqualTo (x:obj) = CustomMatcher<obj>(sprintf "Greater than or equal to %A" x,
                                               fun actual -> (unbox actual :> IComparable).CompareTo(unbox x) >= 0)
 
-let lessThan (x:obj) = CustomMatcher<obj>(sprintf "Less than %s" (string x),
+let lessThan (x:obj) = CustomMatcher<obj>(sprintf "Less than %A" x,
                                     fun actual -> (unbox actual :> IComparable).CompareTo(unbox x) < 0)
 
-let lessThanOrEqualTo (x:obj) = CustomMatcher<obj>(sprintf "Less than or equal to %s" (string x),
+let lessThanOrEqualTo (x:obj) = CustomMatcher<obj>(sprintf "Less than or equal to %A" x,
                                            fun actual -> (unbox actual :> IComparable).CompareTo(unbox x) <= 0)
 
 let endWith (x:string) = CustomMatcher<obj>(string x, fun s -> (string s).EndsWith x)


### PR DESCRIPTION
Hi!

I was experiencing a few weird error messages, like 
```
Error Message:
 FsUnit.Xunit+MatchException : Exception of type 'FsUnit.Xunit+MatchException' was thrown.
Expected: 1
Actual:   was 1
```
which does not make a lot of sense, so I added some slightly more meaningful messages to those matchers.