### PR TITLE
Remove documentation reference to expired link.

### DIFF
--- a/docs/content/MbUnit.fsx
+++ b/docs/content/MbUnit.fsx
@@ -82,7 +82,7 @@ module ``LightBulb Tests`` =
 (**
 BowlingGame
 ---------
-Thanks to `Keith Nicholas` and `Julian` from hubFS for [this example](http://cs.hubfs.net/forums/thread/3938.aspx)!
+Thanks to `Keith Nicholas` and `Julian` from hubFS for this example!
 *)
 module ``BowlingGame A game of bowling`` =
     open MbUnit.Framework

--- a/docs/content/MsTest.fsx
+++ b/docs/content/MsTest.fsx
@@ -82,7 +82,7 @@ module ``LightBulb Tests`` =
 (**
 BowlingGame
 ---------
-Thanks to `Keith Nicholas` and `Julian` from hubFS for [this example](http://cs.hubfs.net/forums/thread/3938.aspx)!
+Thanks to `Keith Nicholas` and `Julian` from hubFS for this example!
 *)
 module ``BowlingGame A game of bowling`` =
     open Microsoft.VisualStudio.TestTools.UnitTesting

--- a/docs/content/NUnit.fsx
+++ b/docs/content/NUnit.fsx
@@ -92,7 +92,7 @@ module ``LightBulb Tests`` =
 (**
 BowlingGame
 ---------
-Thanks to `Keith Nicholas` and `Julian` from hubFS for [this example](http://cs.hubfs.net/forums/thread/3938.aspx)!
+Thanks to `Keith Nicholas` and `Julian` from hubFS for this example!
 *)
 module ``BowlingGame A game of bowling`` =
     open NUnit.Framework

--- a/docs/content/xUnit.fsx
+++ b/docs/content/xUnit.fsx
@@ -80,7 +80,7 @@ module ``LightBulb Tests`` =
 (**
 BowlingGame
 ---------
-Thanks to `Keith Nicholas` and `Julian` from hubFS for [this example](http://cs.hubfs.net/forums/thread/3938.aspx)!
+Thanks to `Keith Nicholas` and `Julian` from hubFS for this example!
 *)
 module ``BowlingGame A game of bowling`` =
     open Xunit


### PR DESCRIPTION
As per #126 remove link to hubFs which no longer appears to be valid.