### PR TITLE
no printfn from equality check

### DIFF
--- a/src/FsUnit.NUnit/Equality.fs
+++ b/src/FsUnit.NUnit/Equality.fs
@@ -9,28 +9,13 @@ open NUnit.Framework.Constraints
 
 type Equality<'T when 'T: equality> =
     static member Reference =
-        System.Func<'T, 'T, bool>(fun x y ->
-            let f =
-                FastGenericEqualityComparer<'T>.Equals(x, y)
-
-            printfn "Ref returns %b" f
-            f)
+        Func<'T, 'T, bool>(fun x y -> FastGenericEqualityComparer<'T>.Equals(x, y))
 
     static member Structural =
-        System.Func<'T, 'T, bool>(fun x y ->
-            let f =
-                StructuralComparisons.StructuralEqualityComparer.Equals(x, y)
-
-            printfn "Struct returns %b" f
-            f)
+        Func<'T, 'T, bool>(fun x y -> StructuralComparisons.StructuralEqualityComparer.Equals(x, y))
 
     static member StructuralC =
-        Comparison<'T>(fun x y ->
-            let f =
-                StructuralComparisons.StructuralComparer.Compare(x, y)
-
-            printfn "Struct returns %d" f
-            f)
+        Comparison<'T>(fun x y -> StructuralComparisons.StructuralComparer.Compare(x, y))
 
     static member inline IsEqualTo(x: 'T) =
         match (box x) with


### PR DESCRIPTION
Fix to code  from https://github.com/fsprojects/FsUnit/pull/147

@marklam am I right that these `printfn` are debug informations that should be removed?