### PR TITLE
DisableImplicitFrameworkReferences for DesignTimeBuild

### DIFF
--- a/src/FsUnit.MsTestUnit/FsUnit.MsTest.fsproj
+++ b/src/FsUnit.MsTestUnit/FsUnit.MsTest.fsproj
@@ -5,6 +5,9 @@
     <AssemblyName>FsUnit.MsTest</AssemblyName>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
+  <PropertyGroup Condition="($(DesignTimeBuild) == true)">
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="..\Common.fs">

--- a/src/FsUnit.NUnit/FsUnit.NUnit.fsproj
+++ b/src/FsUnit.NUnit/FsUnit.NUnit.fsproj
@@ -5,6 +5,9 @@
     <AssemblyName>FsUnit.NUnit</AssemblyName>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
+  <PropertyGroup Condition="($(DesignTimeBuild) == true)">
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="..\Common.fs">

--- a/src/FsUnit.Xunit/FsUnit.Xunit.fsproj
+++ b/src/FsUnit.Xunit/FsUnit.Xunit.fsproj
@@ -5,6 +5,9 @@
     <AssemblyName>FsUnit.Xunit</AssemblyName>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
+  <PropertyGroup Condition="($(DesignTimeBuild) == true)">
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="..\Common.fs">


### PR DESCRIPTION
I got this warnings in Visual Studio: 

![image](https://user-images.githubusercontent.com/4574031/87884361-4c7f8580-ca0e-11ea-9097-7c8fc7deda84.png)

And found a workaround from here:
https://github.com/fsprojects/Paket/issues/2852#issuecomment-557139827

After applying this changes in the PR these warnings disappear.