### PR TITLE
Fixes #170

### DIFF
--- a/src/FsUnit.NUnit/Equality.fs
+++ b/src/FsUnit.NUnit/Equality.fs
@@ -20,8 +20,8 @@ type Equality<'T when 'T: equality> =
 
     static member inline IsEqualTo(x: 'T) =
         match (box x) with
-        | :? IStructuralComparable -> Is.EqualTo(x).Or.EqualTo(x).Using<'T>(Equality.StructuralC)
         | :? IStructuralEquatable -> Is.EqualTo(x).Or.EqualTo(x).Using<'T>(Equality.Structural)
+        | :? IStructuralComparable -> Is.EqualTo(x).Or.EqualTo(x).Using<'T>(Equality.StructuralC)
         | _ -> Is.EqualTo(x)
 
     static member IsNotEqualTo(x: 'T) =

--- a/tests/FsUnit.MsTest.Test/equalTests.fs
+++ b/tests/FsUnit.MsTest.Test/equalTests.fs
@@ -1,5 +1,6 @@
 namespace FsUnit.Test
 
+open System
 open System.Collections.Immutable
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
@@ -110,3 +111,10 @@ type ``equal Tests``() =
     [<TestMethod>]
     member __.``structural value type should not equal non-equivalent value``() =
         anImmutableArray |> should not' (equal otherImmutableArray)
+
+    [<TestMethod>]
+    member __.``structural comparable type containing non-equivalent structural equatable type fails with correct exception``() =
+        let array1 = ImmutableArray.Create(Uri("http://example.com/1"))
+        let array2 = ImmutableArray.Create(Uri("http://example.com/2"))
+
+        shouldFail(fun () -> array1 |> should equal array2)

--- a/tests/FsUnit.NUnit.Test/equalTests.fs
+++ b/tests/FsUnit.NUnit.Test/equalTests.fs
@@ -120,3 +120,10 @@ type ``equal Tests``() =
     [<Test>]
     member __.``structural value type should not equal non-equivalent value``() =
         anImmutableArray |> should not' (equal otherImmutableArray)
+
+    [<Test>]
+    member __.``structural comparable type containing non-equivalent structural equatable type fails with correct exception``() =
+        let array1 = ImmutableArray.Create(Uri("http://example.com/1"))
+        let array2 = ImmutableArray.Create(Uri("http://example.com/2"))
+
+        shouldFail(fun () -> array1 |> should equal array2)

--- a/tests/FsUnit.NUnit.Test/typed.shouldEqualTests.fs
+++ b/tests/FsUnit.NUnit.Test/typed.shouldEqualTests.fs
@@ -123,3 +123,10 @@ type ``shouldEqual Tests``() =
     [<Test>]
     member __.``structural value type should not equal non-equivalent value``() =
         anImmutableArray |> shouldNotEqual otherImmutableArray
+
+    [<Test>]
+    member __.``structural comparable type containing non-equivalent structural equatable type fails with correct exception``() =
+        let array1 = ImmutableArray.Create(Uri("http://example.com/1"))
+        let array2 = ImmutableArray.Create(Uri("http://example.com/2"))
+
+        shouldFail(fun () -> array1 |> shouldEqual array2)

--- a/tests/FsUnit.Xunit.Test/equalTests.fs
+++ b/tests/FsUnit.Xunit.Test/equalTests.fs
@@ -1,5 +1,6 @@
 namespace FsUnit.Test
 
+open System
 open System.Collections.Immutable
 
 open Xunit
@@ -102,3 +103,10 @@ type ``equal Tests``() =
         |> fun f -> Assert.Throws<MatchException>(f)
         |> fun e -> (e.Expected, e.Actual)
         |> should equal ("Equals Ok \"bar\"", "Ok \"foo\"")
+
+    [<Fact>]
+    member __.``structural comparable type containing non-equivalent structural equatable type fails with correct exception``() =
+        let array1 = ImmutableArray.Create(Uri("http://example.com/1"))
+        let array2 = ImmutableArray.Create(Uri("http://example.com/2"))
+
+        shouldFail(fun () -> array1 |> should equal array2)


### PR DESCRIPTION
Prefer IStructuralEquatable to IStructuralComparable to fix a problem where an ArgumentException is reported instead of an Assertion Failure