### PR TITLE
Fix License information and packing the sample files.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 4.0.2 - Nov 07, 2020
+- Fix license information and sample nuget packages. - https://github.com/fsprojects/FsUnit/pull/176
+
 ### 4.0.1 - Jul 31, 2020
 - Prefer IStructuralEquatable to IStructuralComparable - https://github.com/fsprojects/FsUnit/pull/171
 

--- a/src/FsUnit.MsTestUnit/AssemblyInfo.fs
+++ b/src/FsUnit.MsTestUnit/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsUnit.MsTest")>]
 [<assembly: AssemblyProductAttribute("FsUnit")>]
 [<assembly: AssemblyDescriptionAttribute("FsUnit is a set of libraries that makes unit-testing with F# more enjoyable.")>]
-[<assembly: AssemblyVersionAttribute("4.0.1")>]
-[<assembly: AssemblyFileVersionAttribute("4.0.1")>]
+[<assembly: AssemblyVersionAttribute("4.0.2")>]
+[<assembly: AssemblyFileVersionAttribute("4.0.2")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsUnit.MsTest"
     let [<Literal>] AssemblyProduct = "FsUnit"
     let [<Literal>] AssemblyDescription = "FsUnit is a set of libraries that makes unit-testing with F# more enjoyable."
-    let [<Literal>] AssemblyVersion = "4.0.1"
-    let [<Literal>] AssemblyFileVersion = "4.0.1"
+    let [<Literal>] AssemblyVersion = "4.0.2"
+    let [<Literal>] AssemblyFileVersion = "4.0.2"

--- a/src/FsUnit.MsTestUnit/paket.template
+++ b/src/FsUnit.MsTestUnit/paket.template
@@ -1,6 +1,6 @@
 type file
 id
-	Fs30Unit.MsTest
+    Fs30Unit.MsTest
 owners
     Ray Vernagus and Daniel Mohl
 authors
@@ -10,7 +10,7 @@ projectUrl
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/LICENSE.txt
+    http://github.com/fsprojects/FsUnit/blob/master/license.txt
 requireLicenseAcceptance
     false
 copyright

--- a/src/FsUnit.MsTestUnit/sample.paket.template
+++ b/src/FsUnit.MsTestUnit/sample.paket.template
@@ -1,6 +1,6 @@
 ﻿type file
 id
-	Fs30Unit.MsTest.Sample
+    Fs30Unit.MsTest.Sample
 owners
     Ray Vernagus and Daniel Mohl
 authors
@@ -10,11 +10,11 @@ projectUrl
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/LICENSE.txt
+    http://github.com/fsprojects/FsUnit/blob/master/license.txt
 requireLicenseAcceptance
     false
 copyright
-    Copyright 2015
+    Copyright 2015-2020
 tags
     F# fsharp MsTest FsUnit
 summary
@@ -22,6 +22,6 @@ summary
 description
     FsUnit is a set of extensions that add special testing syntax to MsTest.
 dependencies
-	Fs30Unit.MsTest
+    Fs30Unit.MsTest
 files
-	../../bin/FsUnit.MsTest/*.pp ==> content
+    ../../bin/FsUnit.MsTest/**/*.pp ==> content

--- a/src/FsUnit.NUnit/AssemblyInfo.fs
+++ b/src/FsUnit.NUnit/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsUnit.NUnit")>]
 [<assembly: AssemblyProductAttribute("FsUnit")>]
 [<assembly: AssemblyDescriptionAttribute("FsUnit is a set of libraries that makes unit-testing with F# more enjoyable.")>]
-[<assembly: AssemblyVersionAttribute("4.0.1")>]
-[<assembly: AssemblyFileVersionAttribute("4.0.1")>]
+[<assembly: AssemblyVersionAttribute("4.0.2")>]
+[<assembly: AssemblyFileVersionAttribute("4.0.2")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsUnit.NUnit"
     let [<Literal>] AssemblyProduct = "FsUnit"
     let [<Literal>] AssemblyDescription = "FsUnit is a set of libraries that makes unit-testing with F# more enjoyable."
-    let [<Literal>] AssemblyVersion = "4.0.1"
-    let [<Literal>] AssemblyFileVersion = "4.0.1"
+    let [<Literal>] AssemblyVersion = "4.0.2"
+    let [<Literal>] AssemblyFileVersion = "4.0.2"

--- a/src/FsUnit.NUnit/paket.template
+++ b/src/FsUnit.NUnit/paket.template
@@ -1,6 +1,6 @@
 type file
 id
-	FsUnit
+    FsUnit
 owners
     Ray Vernagus and Daniel Mohl
 authors
@@ -10,7 +10,7 @@ projectUrl
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/LICENSE.txt
+    http://github.com/fsprojects/FsUnit/blob/master/license.txt
 requireLicenseAcceptance
     false
 copyright

--- a/src/FsUnit.NUnit/sample.paket.template
+++ b/src/FsUnit.NUnit/sample.paket.template
@@ -1,6 +1,6 @@
 ﻿type file
 id
-	FsUnit.Sample
+    FsUnit.Sample
 owners
     Ray Vernagus and Daniel Mohl
 authors
@@ -10,11 +10,11 @@ projectUrl
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/LICENSE.txt
+    http://github.com/fsprojects/FsUnit/blob/master/license.txt
 requireLicenseAcceptance
     false
 copyright
-    Copyright 2015
+    Copyright 2015-2020
 tags
     F# fsharp NUnit FsUnit
 summary
@@ -22,7 +22,6 @@ summary
 description
     FsUnit is a set of extensions that add special testing syntax to NUnit.
 dependencies
-	FsUnit
+    FsUnit
 files
-	../../bin/FsUnit.NUnit/*.pp ==> content
-
+    ../../bin/FsUnit.NUnit/**/*.pp ==> content

--- a/src/FsUnit.Xunit/AssemblyInfo.fs
+++ b/src/FsUnit.Xunit/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsUnit.Xunit")>]
 [<assembly: AssemblyProductAttribute("FsUnit")>]
 [<assembly: AssemblyDescriptionAttribute("FsUnit is a set of libraries that makes unit-testing with F# more enjoyable.")>]
-[<assembly: AssemblyVersionAttribute("4.0.1")>]
-[<assembly: AssemblyFileVersionAttribute("4.0.1")>]
+[<assembly: AssemblyVersionAttribute("4.0.2")>]
+[<assembly: AssemblyFileVersionAttribute("4.0.2")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsUnit.Xunit"
     let [<Literal>] AssemblyProduct = "FsUnit"
     let [<Literal>] AssemblyDescription = "FsUnit is a set of libraries that makes unit-testing with F# more enjoyable."
-    let [<Literal>] AssemblyVersion = "4.0.1"
-    let [<Literal>] AssemblyFileVersion = "4.0.1"
+    let [<Literal>] AssemblyVersion = "4.0.2"
+    let [<Literal>] AssemblyFileVersion = "4.0.2"

--- a/src/FsUnit.Xunit/paket.template
+++ b/src/FsUnit.Xunit/paket.template
@@ -1,6 +1,6 @@
 type file
 id
-	FsUnit.xUnit
+    FsUnit.xUnit
 owners
     Ray Vernagus and Daniel Mohl
 authors
@@ -10,7 +10,7 @@ projectUrl
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/LICENSE.txt
+    http://github.com/fsprojects/FsUnit/blob/master/license.txt
 requireLicenseAcceptance
     false
 copyright

--- a/src/FsUnit.Xunit/sample.paket.template
+++ b/src/FsUnit.Xunit/sample.paket.template
@@ -1,6 +1,6 @@
 ﻿type file
 id
-	FsUnit.xUnit.Sample
+    FsUnit.xUnit.Sample
 owners
     Ray Vernagus and Daniel Mohl
 authors
@@ -10,11 +10,11 @@ projectUrl
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/LICENSE.txt
+    http://github.com/fsprojects/FsUnit/blob/master/license.txt
 requireLicenseAcceptance
     false
 copyright
-    Copyright 2015
+    Copyright 2015-2020
 tags
     F# fsharp xUnit FsUnit
 summary
@@ -22,6 +22,6 @@ summary
 description
     FsUnit is a set of extensions that add special testing syntax to xUnit.
 dependencies
-	FsUnit.xUnit
+    FsUnit.xUnit
 files
-	../../bin/FsUnit.Xunit/*.pp ==> content
+    ../../bin/FsUnit.Xunit/**/*.pp ==> content


### PR DESCRIPTION
While packing the nuget packages using `dotnet paket pack ...` the following warnings appeared:
![image](https://user-images.githubusercontent.com/4574031/98291554-95eae500-1fab-11eb-8071-9c7a096273e3.png)
After that I downloaded the sample packages, depacked them and found no content in it.



Click on "License Info" refers to "https://github.com/fsprojects/FsUnit/blob/master/LICENSE.txt" but it's "license.txt":

![image](https://user-images.githubusercontent.com/4574031/98291690-d6e2f980-1fab-11eb-9d19-757cdea0a64d.png)
