### PR TITLE
Fix: FsUnit image for Android GitHub App.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FsUnit
 
-<img align="right" width="100" style="margin-left:20px" src="https://github.com/fsprojects/fsunit/blob/master/docs/img/logo.png?raw=true">
+<img align="right" width="100" style="margin-left:20px" src="https://raw.githubusercontent.com/fsprojects/fsunit/master/docs/img/logo.png">
 
 [![Build Status](https://github.com/fsprojects/FsUnit/workflows/Build%20and%20Test/badge.svg?branch=master)](https://github.com/fsprojects/FsUnit/actions?query=branch%3Amaster)
 
@@ -23,7 +23,7 @@ A few things to keep in mind:
 
 * Development environments need to be setup to run tests for xUnit and NUnit. A product like ReSharper can make this easier.
 
-* Since the unit tests for FsUnit are written with FsUnit, failing tests are just as important as passing tests.  
+* Since the unit tests for FsUnit are written with FsUnit, failing tests are just as important as passing tests.
 
 
 ## Maintainer(s)


### PR DESCRIPTION
This will fix an issue that appeared in the GitHub App for Android that annoys me a lot. 😄 

Here's the current master with it's `README.md` with a "grey square" at the top: 
![image](https://user-images.githubusercontent.com/4574031/99955010-ec199f80-2d83-11eb-9c8f-1979d1372992.png)

and the fix for that with our FsUnit image at the top:
![image](https://user-images.githubusercontent.com/4574031/99955222-3c90fd00-2d84-11eb-88bc-1c47bd3eeb4f.png)

@sergey-tihon Comments? 🙂 