### PR TITLE
Add and unify badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img align="right" width="100" style="margin-left:20px" src="https://raw.githubusercontent.com/fsprojects/fsunit/master/docs/img/logo.png">
 
-[![Build Status](https://img.shields.io/github/workflow/status/fsprojects/FsUnit/Build%20and%20Test.svg?logo=github&label=Build%20and%20Test)](https://github.com/fsprojects/FsUnit/actions?query=branch%3Amaster)
+[![Build Status](https://img.shields.io/github/workflow/status/fsprojects/FsUnit/Build%20and%20Test.svg?logo=github&labelColor=4A4A4A&label=Build%20and%20Test)](https://github.com/fsprojects/FsUnit/actions?query=branch%3Amaster)
 [![NuGet Status](https://buildstats.info/nuget/FsUnit)](https://www.nuget.org/packages/FsUnit/)
 
 **FsUnit** is a set of libraries that makes unit-testing with F# more enjoyable. It adds a special syntax to your favorite .NET testing framework.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 <img align="right" width="100" style="margin-left:20px" src="https://raw.githubusercontent.com/fsprojects/fsunit/master/docs/img/logo.png">
 
 [![Build Status](https://img.shields.io/github/workflow/status/fsprojects/FsUnit/Build%20and%20Test.svg?logo=github&label=Build%20and%20Test)](https://github.com/fsprojects/FsUnit/actions?query=branch%3Amaster)
-[![FsUnit Downloads](https://img.shields.io/nuget/dt/FsUnit.svg?logo=nuget)](https://www.nuget.org/packages/FsUnit/)
-[![FsUnit Version](https://img.shields.io/nuget/v/FsUnit.svg?logo=nuget)](https://www.nuget.org/packages/FsUnit/)
+[![NuGet Status](https://buildstats.info/nuget/FsUnit)](https://www.nuget.org/packages/FsUnit/)
 
 **FsUnit** is a set of libraries that makes unit-testing with F# more enjoyable. It adds a special syntax to your favorite .NET testing framework.
 FsUnit currently supports NUnit, xUnit, and MsTest.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 <img align="right" width="100" style="margin-left:20px" src="https://raw.githubusercontent.com/fsprojects/fsunit/master/docs/img/logo.png">
 
-[![Build Status](https://github.com/fsprojects/FsUnit/workflows/Build%20and%20Test/badge.svg?branch=master)](https://github.com/fsprojects/FsUnit/actions?query=branch%3Amaster)
+[![Build Status](https://img.shields.io/github/workflow/status/fsprojects/FsUnit/Build%20and%20Test.svg?logo=github&label=Build%20and%20Test)](https://github.com/fsprojects/FsUnit/actions?query=branch%3Amaster)
+[![FsUnit Downloads](https://img.shields.io/nuget/dt/FsUnit.svg?logo=nuget)](https://www.nuget.org/packages/FsUnit/)
+[![FsUnit Version](https://img.shields.io/nuget/v/FsUnit.svg?logo=nuget)](https://www.nuget.org/packages/FsUnit/)
 
 **FsUnit** is a set of libraries that makes unit-testing with F# more enjoyable. It adds a special syntax to your favorite .NET testing framework.
 FsUnit currently supports NUnit, xUnit, and MsTest.


### PR DESCRIPTION
This adds and unifies the badges in the Readme.md with shields.io badges.

1. Replaces github workflow badge [Line 5]
2. Adds the nuget dowload count badge and refers it [Line 6]
3. Adds the nuget version badge and refers it [Line 7]

@sergey-tihon I hope you like this little update. 🙂 