### PR TITLE
Update license URL

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 4.2.0 - Dec 23, 2021
+- Adjust license URL to be the raw link, fix http --> https
+
 ### 4.1.0 - Nov 14, 2021
 - Add net6.0 support. - https://github.com/fsprojects/FsUnit/pull/194
 - Drop F# 4.7.x support.

--- a/build.fsx
+++ b/build.fsx
@@ -202,7 +202,7 @@ Target.create "PublishNuget" (fun _ ->
 
 Target.create "GenerateDocs" (fun _ ->
    Shell.cleanDir ".fsdocs"
-   DotNet.exec id "fsdocs" "build --clean --parameters root http://fsprojects.github.io/FsUnit" |> ignore
+   DotNet.exec id "fsdocs" "build --clean --parameters root https://fsprojects.github.io/FsUnit" |> ignore
 )
 // --------------------------------------------------------------------------------------
 // Release Scripts

--- a/docs/_template.html
+++ b/docs/_template.html
@@ -18,7 +18,7 @@
     <script type="text/javascript" src="./content/fsdocs-tips.js"></script>
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <!-- BEGIN SEARCH BOX: this adds support for the search box -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.4/auto-complete.css" />
@@ -32,7 +32,7 @@
             <ul class="nav nav-pills pull-right">
                 <li><a href="https://fscheck.github.io/FsCheck/">FsCheck</a></li>
                 <li><a href="https://github.com/fsprojects/Foq">Foq</a></li>
-                <li><a href="http://fsharp.org">fsharp.org</a></li>
+                <li><a href="https://fsharp.org">fsharp.org</a></li>
             </ul>
             <h3 class="muted"><a href="./index.html">{{fsdocs-collection-name}}</a></h3>
         </div>

--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -189,7 +189,7 @@ the project and submit pull requests. If you're adding a new public API, please 
 consider adding [samples][content] that can be turned into a documentation. You might
 also want to read the [library design notes][readme] to understand how it works.
 
-  [content]: http://fsprojects.github.io/FsUnit/#Syntax
+  [content]: https://fsprojects.github.io/FsUnit/#Syntax
   [gh]: https://github.com/fsprojects/FsUnit
   [issues]: https://github.com/fsprojects/FsUnit/issues
   [readme]: https://github.com/fsprojects/FsUnit/blob/master/README.md

--- a/src/FsUnit.MsTestUnit/paket.template
+++ b/src/FsUnit.MsTestUnit/paket.template
@@ -6,11 +6,11 @@ owners
 authors
     Ray Vernagus, Daniel Mohl, Sergey Tihon, Constantin Tews
 projectUrl
-    http://github.com/fsprojects/FsUnit
+    https://github.com/fsprojects/FsUnit
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/license.txt
+    https://raw.githubusercontent.com/fsprojects/FsUnit/master/license.txt
 requireLicenseAcceptance
     false
 copyright

--- a/src/FsUnit.MsTestUnit/sample.paket.template
+++ b/src/FsUnit.MsTestUnit/sample.paket.template
@@ -6,11 +6,11 @@ owners
 authors
     Ray Vernagus, Daniel Mohl, Sergey Tihon, Constantin Tews
 projectUrl
-    http://github.com/fsprojects/FsUnit
+    https://github.com/fsprojects/FsUnit
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/license.txt
+    https://github.com/fsprojects/FsUnit/blob/master/license.txt
 requireLicenseAcceptance
     false
 copyright

--- a/src/FsUnit.NUnit/paket.template
+++ b/src/FsUnit.NUnit/paket.template
@@ -6,11 +6,11 @@ owners
 authors
     Ray Vernagus, Daniel Mohl, Sergey Tihon, Constantin Tews
 projectUrl
-    http://github.com/fsprojects/FsUnit
+    https://github.com/fsprojects/FsUnit
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/license.txt
+    https://raw.githubusercontent.com/fsprojects/FsUnit/master/license.txt
 requireLicenseAcceptance
     false
 copyright

--- a/src/FsUnit.NUnit/sample.paket.template
+++ b/src/FsUnit.NUnit/sample.paket.template
@@ -6,11 +6,11 @@ owners
 authors
     Ray Vernagus, Daniel Mohl, Sergey Tihon, Constantin Tews
 projectUrl
-    http://github.com/fsprojects/FsUnit
+    https://github.com/fsprojects/FsUnit
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/license.txt
+    https://github.com/fsprojects/FsUnit/blob/master/license.txt
 requireLicenseAcceptance
     false
 copyright

--- a/src/FsUnit.Xunit/paket.template
+++ b/src/FsUnit.Xunit/paket.template
@@ -6,7 +6,7 @@ owners
 authors
     Ray Vernagus, Daniel Mohl, Sergey Tihon, Constantin Tews
 projectUrl
-    http://github.com/fsprojects/FsUnit
+    https://github.com/fsprojects/FsUnit
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl

--- a/src/FsUnit.Xunit/paket.template
+++ b/src/FsUnit.Xunit/paket.template
@@ -10,7 +10,7 @@ projectUrl
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/license.txt
+    https://raw.githubusercontent.com/fsprojects/FsUnit/master/license.txt
 requireLicenseAcceptance
     false
 copyright

--- a/src/FsUnit.Xunit/sample.paket.template
+++ b/src/FsUnit.Xunit/sample.paket.template
@@ -6,11 +6,11 @@ owners
 authors
     Ray Vernagus, Daniel Mohl, Sergey Tihon, Constantin Tews
 projectUrl
-    http://github.com/fsprojects/FsUnit
+    https://github.com/fsprojects/FsUnit
 iconUrl
     https://raw.githubusercontent.com/fsprojects/FsUnit/master/docs/img/logo.png
 licenseUrl
-    http://github.com/fsprojects/FsUnit/blob/master/license.txt
+    https://github.com/fsprojects/FsUnit/blob/master/license.txt
 requireLicenseAcceptance
     false
 copyright

--- a/tests/FsUnit.MsTest.Test/equalTests.fs
+++ b/tests/FsUnit.MsTest.Test/equalTests.fs
@@ -115,9 +115,9 @@ type ``equal Tests``() =
     [<TestMethod>]
     member __.``structural comparable type containing non-equivalent structural equatable type fails with correct exception``() =
         let array1 =
-            ImmutableArray.Create(Uri("http://example.com/1"))
+            ImmutableArray.Create(Uri("https://example.com/1"))
 
         let array2 =
-            ImmutableArray.Create(Uri("http://example.com/2"))
+            ImmutableArray.Create(Uri("https://example.com/2"))
 
         shouldFail(fun () -> array1 |> should equal array2)

--- a/tests/FsUnit.MsTest.Test/equalWithinTests.fs
+++ b/tests/FsUnit.MsTest.Test/equalWithinTests.fs
@@ -3,7 +3,7 @@ namespace FsUnit.Test
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open FsUnit.MsTest
 
-(* Thanks to erdoll for this suggestion: http://fsunit.codeplex.com/discussions/269320 *)
+(* Thanks to erdoll for this suggestion: https://fsunit.codeplex.com/discussions/269320 *)
 
 [<TestClass>]
 type ``equalWithin tests``() =

--- a/tests/FsUnit.NUnit.Test/equalTests.fs
+++ b/tests/FsUnit.NUnit.Test/equalTests.fs
@@ -124,9 +124,9 @@ type ``equal Tests``() =
     [<Test>]
     member __.``structural comparable type containing non-equivalent structural equatable type fails with correct exception``() =
         let array1 =
-            ImmutableArray.Create(Uri("http://example.com/1"))
+            ImmutableArray.Create(Uri("https://example.com/1"))
 
         let array2 =
-            ImmutableArray.Create(Uri("http://example.com/2"))
+            ImmutableArray.Create(Uri("https://example.com/2"))
 
         shouldFail(fun () -> array1 |> should equal array2)

--- a/tests/FsUnit.NUnit.Test/equalWithinTests.fs
+++ b/tests/FsUnit.NUnit.Test/equalWithinTests.fs
@@ -3,7 +3,7 @@ namespace FsUnit.Test
 open NUnit.Framework
 open FsUnit
 
-(* Thanks to erdoll for this suggestion: http://fsunit.codeplex.com/discussions/269320 *)
+(* Thanks to erdoll for this suggestion: https://fsunit.codeplex.com/discussions/269320 *)
 
 [<TestFixture>]
 type ``equalWithin tests``() =

--- a/tests/FsUnit.NUnit.Test/typed.shouldEqualTests.fs
+++ b/tests/FsUnit.NUnit.Test/typed.shouldEqualTests.fs
@@ -127,9 +127,9 @@ type ``shouldEqual Tests``() =
     [<Test>]
     member __.``structural comparable type containing non-equivalent structural equatable type fails with correct exception``() =
         let array1 =
-            ImmutableArray.Create(Uri("http://example.com/1"))
+            ImmutableArray.Create(Uri("https://example.com/1"))
 
         let array2 =
-            ImmutableArray.Create(Uri("http://example.com/2"))
+            ImmutableArray.Create(Uri("https://example.com/2"))
 
         shouldFail(fun () -> array1 |> shouldEqual array2)

--- a/tests/FsUnit.Xunit.Test/equalTests.fs
+++ b/tests/FsUnit.Xunit.Test/equalTests.fs
@@ -107,9 +107,9 @@ type ``equal Tests``() =
     [<Fact>]
     member __.``structural comparable type containing non-equivalent structural equatable type fails with correct exception``() =
         let array1 =
-            ImmutableArray.Create(Uri("http://example.com/1"))
+            ImmutableArray.Create(Uri("https://example.com/1"))
 
         let array2 =
-            ImmutableArray.Create(Uri("http://example.com/2"))
+            ImmutableArray.Create(Uri("https://example.com/2"))
 
         shouldFail(fun () -> array1 |> should equal array2)

--- a/tests/FsUnit.Xunit.Test/equalWithinTests.fs
+++ b/tests/FsUnit.Xunit.Test/equalWithinTests.fs
@@ -3,7 +3,7 @@ namespace FsUnit.Test
 open Xunit
 open FsUnit.Xunit
 
-(* Thanks to erdoll for this suggestion: http://fsunit.codeplex.com/discussions/269320 *)
+(* Thanks to erdoll for this suggestion: https://fsunit.codeplex.com/discussions/269320 *)
 
 type ``equalWithin tests``() =
     [<Fact>]


### PR DESCRIPTION
ClearlyDefined seems to prefer the direct license URL, cc @baronfel 

https://clearlydefined.io/?sortDesc=true&sort=releaseDate&name=FsUnit.xUnit

Possibly also requires http --> https
