### PR TITLE
Add Expecto link to docs

### DIFF
--- a/docs/Expecto.fsx
+++ b/docs/Expecto.fsx
@@ -1,0 +1,59 @@
+(*** hide ***)
+#r "nuget: Expecto"
+
+(**
+Expecto
+========================
+
+<div class="row">
+  <div class="span1"></div>
+  <div class="span6">
+    <div class="well well-small" id="nuget">
+      The Expecto library can be <a href="https://nuget.org/packages/Expecto">installed from NuGet</a>:
+      <pre>PM> Install-Package Expecto</pre>
+    </div>
+  </div>
+  <div class="span1"></div>
+</div>
+*)
+
+(**
+**Expecto.Flip** has a similar syntax to `FsUnit`.
+
+`Expecto` is **not** part of FsUnit.
+
+Syntax
+-------
+
+With `Expecto.Flip` you can write your unit tests like this:
+
+*)
+
+open Expecto.Flip.Expect
+
+(**
+One object equals or does not equal another:
+*)
+
+1 |> equal "1 is equal to 1." 1
+1 |> notEqual  "1 is not equal to 2." 2
+
+(**
+One comparable value greater or smaller than another:
+*)
+
+(11, 10) |> isGreaterThan "11 is greater than 10."
+(10, 11) |> isLessThan "10 is less than 11."
+
+(**
+& more operators:
+*)
+
+true |> isTrue "Value is true."
+false |> isFalse "Value is false."
+
+"" |> isEmpty
+"Foobar" |> isNotEmpty "Value is not empty."
+None |> isNone "Value is None."
+
+{1 .. 10} |> contains "Seq 1 to 10 contains 4." 4

--- a/docs/Expecto.fsx
+++ b/docs/Expecto.fsx
@@ -57,3 +57,7 @@ false |> isFalse "Value is false."
 None |> isNone "Value is None."
 
 {1 .. 10} |> contains "Seq 1 to 10 contains 4." 4
+
+(**
+All operators are listed here: <a href="https://github.com/haf/expecto/blob/main/Expecto/Flip.Expect.fs">Expecto.Flip.Expect</a>
+*)

--- a/docs/_template.html
+++ b/docs/_template.html
@@ -30,6 +30,7 @@
     <div class="container">
         <div class="masthead">
             <ul class="nav nav-pills pull-right">
+                <li><a href="https://github.com/haf/expecto">Expecto</a></li>
                 <li><a href="https://fscheck.github.io/FsCheck/">FsCheck</a></li>
                 <li><a href="https://github.com/fsprojects/Foq">Foq</a></li>
                 <li><a href="https://fsharp.org">fsharp.org</a></li>

--- a/docs/_template.html
+++ b/docs/_template.html
@@ -59,7 +59,7 @@
                     </div>
                 </div> -->
                 <!-- END SEARCH BOX: this adds support for the search box -->
-                
+
                 <ul class="nav nav-list" id="menu">
                     <li class="nav-header">{{fsdocs-collection-name}}</li>
                     <li><a href="./index.html">Home page</a></li>
@@ -78,6 +78,8 @@
                     <li class="nav-header">Documentation</li>
                     <li><a href="./operators.html">Operators</a></li>
                     <!-- <li><a href="{{root}}/reference/index.html">API Reference</a></li> -->
+                    <li class="nav-header">Miscellaneous</li>
+                    <li><a href="./Expecto.html">Expecto</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
As discussed in #197, here we add Expecto to the docs. 

We can also add an extra section "MISCELLANEOUS" after "DOCUMENTATION" where we put some code samples of Flip.Expect, a link to it and nothing more.
Of course, we should mention that this is not included in FsUnit and all usable with Expecto.

All in this PR.