### PR TITLE
Use & simplify NUnit/FsUnitTyped assert methods.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -137,7 +137,7 @@ Target.create "CleanDocs" (fun _ ->
 let sourceFiles =
     !! "src/**/*.fs"
       ++ "tests/**/*.fs" 
-      -- "./**/*AssemblyInfo.fs"
+      -- "./**/*Assembly*.fs"
 
 Target.create "CheckFormat" (fun _ ->
     let result =

--- a/src/FsUnit.NUnit/FsUnitTyped.fs
+++ b/src/FsUnit.NUnit/FsUnitTyped.fs
@@ -2,7 +2,6 @@ namespace FsUnitTyped
 
 open System.Diagnostics
 open NUnit.Framework
-open System.Collections.Generic
 
 [<AutoOpen>]
 module TopLevelOperators =
@@ -16,13 +15,8 @@ module TopLevelOperators =
         Assert.That(actual, FsUnit.Equality.IsNotEqualTo(expected))
 
     [<DebuggerStepThrough>]
-    let shouldContain (expected: 'a) (actual: 'a seq) =
-        let list = List<_>()
-
-        for a in actual do
-            list.Add a
-
-        Assert.Contains(expected, list)
+    let shouldContain (actual: 'a) (expected: 'a seq) =
+        Assert.Contains(actual, Seq.toArray expected)
 
     [<DebuggerStepThrough>]
     let shouldBeEmpty(actual: 'a seq) =
@@ -30,16 +24,15 @@ module TopLevelOperators =
 
     [<DebuggerStepThrough>]
     let shouldNotContain (expected: 'a) (actual: 'a seq) =
-        if Seq.exists ((=) expected) actual then
-            failwith $"Seq %A{actual} should not contain %A{expected}"
+        Assert.That(actual, Does.Not.Contain(expected), $"Seq %A{actual} should not contain %A{expected}")
 
     [<DebuggerStepThrough>]
     let shouldBeSmallerThan (expected: 'a) (actual: 'a) =
-        Assert.Less(actual, expected, $"Expected: %A{expected}\nActual: %A{actual}")
+        Assert.Less(actual, expected)
 
     [<DebuggerStepThrough>]
     let shouldBeGreaterThan (expected: 'a) (actual: 'a) =
-        Assert.Greater(actual, expected, $"Expected: %A{expected}\nActual: %A{actual}")
+        Assert.Greater(actual, expected)
 
     [<DebuggerStepThrough>]
     let shouldFail<'exn when 'exn :> exn>(f: unit -> unit) =
@@ -47,17 +40,12 @@ module TopLevelOperators =
 
     [<DebuggerStepThrough>]
     let shouldContainText (expected: string) (actual: string) =
-        if actual.Contains(expected) |> not then
-            failwith $"\"{expected}\" is not a substring of \"{actual}\""
+        Assert.That(actual, Does.Contain(expected), $"\"{expected}\" is not a substring of \"{actual}\"")
 
     [<DebuggerStepThrough>]
     let shouldNotContainText (expected: string) (actual: string) =
-        if actual.Contains(expected) then
-            failwith $"\"{expected}\" is a substring of \"{actual}\""
+        Assert.That(actual, Does.Not.Contain(expected), $"\"{expected}\" is a substring of \"{actual}\"")
 
     [<DebuggerStepThrough>]
-    let shouldHaveLength expected list =
-        let actual = Seq.length list
-
-        if actual <> expected then
-            failwith $"Invalid length in %A{list}\r\nExpected: {expected}\r\nActual: {actual}"
+    let shouldHaveLength expected actual =
+        Assert.That(Seq.length actual, Is.EqualTo(expected), $"Invalid length in %A{actual}")

--- a/src/FsUnit.NUnit/FsUnitTyped.fs
+++ b/src/FsUnit.NUnit/FsUnitTyped.fs
@@ -40,11 +40,11 @@ module TopLevelOperators =
 
     [<DebuggerStepThrough>]
     let shouldContainText (expected: string) (actual: string) =
-        Assert.That(actual, Does.Contain(expected), $"\"{expected}\" is not a substring of \"{actual}\"")
+        StringAssert.Contains(expected, actual)
 
     [<DebuggerStepThrough>]
     let shouldNotContainText (expected: string) (actual: string) =
-        Assert.That(actual, Does.Not.Contain(expected), $"\"{expected}\" is a substring of \"{actual}\"")
+        StringAssert.DoesNotContain(expected, actual)
 
     [<DebuggerStepThrough>]
     let shouldHaveLength (expected: int) actual =

--- a/src/FsUnit.NUnit/FsUnitTyped.fs
+++ b/src/FsUnit.NUnit/FsUnitTyped.fs
@@ -16,7 +16,7 @@ module TopLevelOperators =
 
     [<DebuggerStepThrough>]
     let shouldContain (expected: 'a) (actual: 'a seq) =
-        CollectionAssert.Contains (actual, expected)
+        CollectionAssert.Contains(actual, expected)
 
     [<DebuggerStepThrough>]
     let shouldBeEmpty(actual: 'a seq) =
@@ -24,7 +24,7 @@ module TopLevelOperators =
 
     [<DebuggerStepThrough>]
     let shouldNotContain (expected: 'a) (actual: 'a seq) =
-        CollectionAssert.DoesNotContain (actual, expected, $"Seq %A{actual} should not contain %A{expected}")
+        CollectionAssert.DoesNotContain(actual, expected, $"Seq %A{actual} should not contain %A{expected}")
 
     [<DebuggerStepThrough>]
     let shouldBeSmallerThan (expected: 'a) (actual: 'a) =

--- a/src/FsUnit.NUnit/FsUnitTyped.fs
+++ b/src/FsUnit.NUnit/FsUnitTyped.fs
@@ -15,8 +15,8 @@ module TopLevelOperators =
         Assert.That(actual, FsUnit.Equality.IsNotEqualTo(expected))
 
     [<DebuggerStepThrough>]
-    let shouldContain (actual: 'a) (expected: 'a seq) =
-        Assert.Contains(actual, Seq.toArray expected)
+    let shouldContain (expected: 'a) (actual: 'a seq) =
+        CollectionAssert.Contains (actual, expected)
 
     [<DebuggerStepThrough>]
     let shouldBeEmpty(actual: 'a seq) =
@@ -24,7 +24,7 @@ module TopLevelOperators =
 
     [<DebuggerStepThrough>]
     let shouldNotContain (expected: 'a) (actual: 'a seq) =
-        Assert.That(actual, Does.Not.Contain(expected), $"Seq %A{actual} should not contain %A{expected}")
+        CollectionAssert.DoesNotContain (actual, expected, $"Seq %A{actual} should not contain %A{expected}")
 
     [<DebuggerStepThrough>]
     let shouldBeSmallerThan (expected: 'a) (actual: 'a) =
@@ -47,5 +47,5 @@ module TopLevelOperators =
         Assert.That(actual, Does.Not.Contain(expected), $"\"{expected}\" is a substring of \"{actual}\"")
 
     [<DebuggerStepThrough>]
-    let shouldHaveLength expected actual =
+    let shouldHaveLength (expected: int) actual =
         Assert.That(Seq.length actual, Is.EqualTo(expected), $"Invalid length in %A{actual}")


### PR DESCRIPTION
Fully use NUnit asserts to have consistency in `FsUnitTyped.fs`.

@sergey-tihon What do you think about this change?