### PR TITLE
Fix .NET Framework reference issue

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 5.0.3 - Aug 16, 2022
+- Fixed a reference issue with .NET Framework.
+
 ### 5.0.2 - Aug 15, 2022
 - Dependency update (NHamcrest 2.0.1 => 3.0.1) -> (https://github.com/fsprojects/FsUnit/pull/211)
 

--- a/src/FsUnit.MsTestUnit/AssemblyInfo.fs
+++ b/src/FsUnit.MsTestUnit/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsUnit.MsTest")>]
 [<assembly: AssemblyProductAttribute("FsUnit")>]
 [<assembly: AssemblyDescriptionAttribute("FsUnit is a set of libraries that makes unit-testing with F# more enjoyable.")>]
-[<assembly: AssemblyVersionAttribute("5.0.2")>]
-[<assembly: AssemblyFileVersionAttribute("5.0.2")>]
+[<assembly: AssemblyVersionAttribute("5.0.3")>]
+[<assembly: AssemblyFileVersionAttribute("5.0.3")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsUnit.MsTest"
     let [<Literal>] AssemblyProduct = "FsUnit"
     let [<Literal>] AssemblyDescription = "FsUnit is a set of libraries that makes unit-testing with F# more enjoyable."
-    let [<Literal>] AssemblyVersion = "5.0.2"
-    let [<Literal>] AssemblyFileVersion = "5.0.2"
+    let [<Literal>] AssemblyVersion = "5.0.3"
+    let [<Literal>] AssemblyFileVersion = "5.0.3"

--- a/src/FsUnit.MsTestUnit/paket.template
+++ b/src/FsUnit.MsTestUnit/paket.template
@@ -27,8 +27,6 @@ files
     ../../src/install.ps1 ==> tools
 
 dependencies
-    framework: net6.0
-        MSTest.TestFramework ~> LOCKEDVERSION
-        NHamcrest ~> LOCKEDVERSION
-        FSharp.Core >= LOCKEDVERSION
-    framework: netstandard2.0
+    MSTest.TestFramework ~> LOCKEDVERSION
+    NHamcrest ~> LOCKEDVERSION
+    FSharp.Core >= LOCKEDVERSION

--- a/src/FsUnit.NUnit/AssemblyInfo.fs
+++ b/src/FsUnit.NUnit/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsUnit.NUnit")>]
 [<assembly: AssemblyProductAttribute("FsUnit")>]
 [<assembly: AssemblyDescriptionAttribute("FsUnit is a set of libraries that makes unit-testing with F# more enjoyable.")>]
-[<assembly: AssemblyVersionAttribute("5.0.2")>]
-[<assembly: AssemblyFileVersionAttribute("5.0.2")>]
+[<assembly: AssemblyVersionAttribute("5.0.3")>]
+[<assembly: AssemblyFileVersionAttribute("5.0.3")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsUnit.NUnit"
     let [<Literal>] AssemblyProduct = "FsUnit"
     let [<Literal>] AssemblyDescription = "FsUnit is a set of libraries that makes unit-testing with F# more enjoyable."
-    let [<Literal>] AssemblyVersion = "5.0.2"
-    let [<Literal>] AssemblyFileVersion = "5.0.2"
+    let [<Literal>] AssemblyVersion = "5.0.3"
+    let [<Literal>] AssemblyFileVersion = "5.0.3"

--- a/src/FsUnit.NUnit/paket.template
+++ b/src/FsUnit.NUnit/paket.template
@@ -27,7 +27,5 @@ files
     ../../src/install.ps1 ==> tools
 
 dependencies
-    framework: net6.0
-        NUnit ~> LOCKEDVERSION
-        FSharp.Core >= LOCKEDVERSION
-    framework: netstandard2.0
+    NUnit ~> LOCKEDVERSION
+    FSharp.Core >= LOCKEDVERSION

--- a/src/FsUnit.Xunit/AssemblyInfo.fs
+++ b/src/FsUnit.Xunit/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FsUnit.Xunit")>]
 [<assembly: AssemblyProductAttribute("FsUnit")>]
 [<assembly: AssemblyDescriptionAttribute("FsUnit is a set of libraries that makes unit-testing with F# more enjoyable.")>]
-[<assembly: AssemblyVersionAttribute("5.0.2")>]
-[<assembly: AssemblyFileVersionAttribute("5.0.2")>]
+[<assembly: AssemblyVersionAttribute("5.0.3")>]
+[<assembly: AssemblyFileVersionAttribute("5.0.3")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsUnit.Xunit"
     let [<Literal>] AssemblyProduct = "FsUnit"
     let [<Literal>] AssemblyDescription = "FsUnit is a set of libraries that makes unit-testing with F# more enjoyable."
-    let [<Literal>] AssemblyVersion = "5.0.2"
-    let [<Literal>] AssemblyFileVersion = "5.0.2"
+    let [<Literal>] AssemblyVersion = "5.0.3"
+    let [<Literal>] AssemblyFileVersion = "5.0.3"

--- a/src/FsUnit.Xunit/paket.template
+++ b/src/FsUnit.Xunit/paket.template
@@ -27,8 +27,6 @@ files
     ../../src/install.ps1 ==> tools
 
 dependencies
-    framework: net6.0
-        xunit ~> LOCKEDVERSION
-        NHamcrest ~> LOCKEDVERSION
-        FSharp.Core >= LOCKEDVERSION
-    framework: netstandard2.0
+    xunit ~> LOCKEDVERSION
+    NHamcrest ~> LOCKEDVERSION
+    FSharp.Core >= LOCKEDVERSION


### PR DESCRIPTION
That fixes #212.
There was a little detail I have missed in the `paket.template` for each project.
Restrictions have been removed because the output libraries are the same but the target framework is different.

I have reproduced #212 and tested this solution locally and it works now as expected.

@sergey-tihon I would like ship it as fast as possible.