### PR TITLE
Fix badge on README.md

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
-        dotnet: [6.0.401]
+        dotnet: [7.0.101]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img align="right" width="100" style="margin-left:20px" src="https://raw.githubusercontent.com/fsprojects/fsunit/master/docs/img/logo.png">
 
-[![Build Status](https://img.shields.io/github/workflow/status/fsprojects/FsUnit/Build%20and%20Test.svg?logo=github&labelColor=4A4A4A&label=Build%20and%20Test)](https://github.com/fsprojects/FsUnit/actions?query=branch%3Amaster)
+[![Build Status](https://img.shields.io/github/workflow/status/fsprojects/FsUnit/main.yml?branch=master&logo=github&labelColor=4A4A4A&label=Build%20and%20Test)](https://github.com/fsprojects/FsUnit/actions?query=branch%3Amaster)
 [![NuGet Status](https://buildstats.info/nuget/FsUnit)](https://www.nuget.org/packages/FsUnit/)
 
 **FsUnit** is a set of libraries that makes unit-testing with F# more enjoyable. It adds a special syntax to your favorite .NET testing framework.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.401",
+        "version": "7.0.101",
         "rollForward": "minor"
     }
 }


### PR DESCRIPTION
There was an issue with the badge: 
<img width="265" alt="image" src="https://user-images.githubusercontent.com/4574031/208965158-57969bf8-8566-46a9-adc8-e5ba27349210.png">

Additionally, I updated the SDK for the build runner.

@sergey-tihon FYI: I'll update FsUnit with .NET7 & it's dependencies in the first week of 2023 (with copyright strings in the `paket.template`s) & ofcourse shipping a new version.