### PR TITLE
Add NUnit nuget constraint

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,7 @@ nuget FSharp.Core ~> 5.0.0
 nuget Microsoft.NET.Test.Sdk
 
 // NUnit
-nuget NUnit
+nuget NUnit ~> 3.13.3
 nuget NUnit3TestAdapter
 nuget System.Collections.Immutable
 nuget System.Collections.NonGeneric

--- a/src/FsUnit.NUnit/paket.template
+++ b/src/FsUnit.NUnit/paket.template
@@ -27,5 +27,5 @@ files
     ../../src/install.ps1 ==> tools
 
 dependencies
-    NUnit >= LOCKEDVERSION
+    NUnit >= LOCKEDVERSION < 4.0.0
     FSharp.Core >= LOCKEDVERSION


### PR DESCRIPTION
Reference to #256, with this fix a warning will be thrown when `NUnit 4.0` is installed.
With `FsUnit 5.6.0`: no warning pops up.